### PR TITLE
Add support for OpenCensus traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is an minimal distributed tracing effect for Cats, inspired by earlier work
 
 - [Jaeger](https://www.jaegertracing.io/)
 - [Honeycomb](https://www.honeycomb.io/)
+- [OpenCensus](https://www.opencensus.io/)
 
 It supports
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,8 @@ lazy val natchez = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(publish / skip := true)
-  .dependsOn(core, jaeger, honeycomb, examples)
-  .aggregate(core, jaeger, honeycomb, examples)
+  .dependsOn(core, jaeger, honeycomb, opencensus, examples)
+  .aggregate(core, jaeger, honeycomb, opencensus, examples)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -78,6 +78,19 @@ lazy val honeycomb = project
     description := "Honeycomb support for Natchez.",
     libraryDependencies ++= Seq(
       "io.honeycomb.libhoney" % "libhoney-java" % "1.0.5",
+    )
+  )
+
+lazy val opencensus = project
+  .in(file("modules/opencensus"))
+  .dependsOn(core)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-opencensus",
+    description := "Opencensus support for Natchez.",
+    libraryDependencies ++= Seq(
+      "io.opencensus" % "opencensus-exporter-trace-ocagent" % "0.20.0",
     )
   )
 

--- a/modules/opencensus/README.md
+++ b/modules/opencensus/README.md
@@ -1,0 +1,27 @@
+# OpenCensus
+
+OpenCensus is capable of exporting to different collector types. 
+  Exporters are added registered globally against a singleton registry.
+  There is nothing stopping someone registering a new exporter outside
+  of a side effect, so it is up to the user whether to do so inside the
+  effects system or not.
+  
+The recommended approach for registering exporters is to use a resource.
+  The snippet below shows how this may be done for the OpenCensus agent
+  trace exporter implementation:
+  
+```scala
+  def ocAgentEntryPoint[F[_]: Sync](system: String)(
+      configure: OcAgentTraceExporterConfiguration.Builder => OcAgentTraceExporterConfiguration.Builder)
+    : Resource[F, EntryPoint[F]] =
+    Resource
+      .make(
+        Sync[F].delay(
+          OcAgentTraceExporter.createAndRegister(configure(
+            OcAgentTraceExporterConfiguration.builder().setServiceName(system))
+            .build())))(_ =>
+        Sync[F].delay(
+          OcAgentTraceExporter.unregister()
+      ))
+      .flatMap(_ => Resource.liftF(entryPoint[F]))
+```

--- a/modules/opencensus/src/main/scala/OpenCensus.scala
+++ b/modules/opencensus/src/main/scala/OpenCensus.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package opencensus
+
+import cats.effect.{Resource, Sync}
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.functor._
+import io.opencensus.exporter.trace.ocagent.{
+  OcAgentTraceExporter,
+  OcAgentTraceExporterConfiguration
+}
+import io.opencensus.trace.Tracing
+import io.opencensus.trace.propagation.SpanContextParseException
+import io.opencensus.trace.propagation.TextFormat.Getter
+
+object OpenCensus {
+
+  def ocAgentEntryPoint[F[_]: Sync](system: String)(
+      configure: OcAgentTraceExporterConfiguration.Builder => OcAgentTraceExporterConfiguration.Builder)
+    : Resource[F, EntryPoint[F]] =
+    Resource
+      .make(
+        Sync[F].delay(
+          OcAgentTraceExporter.createAndRegister(configure(
+            OcAgentTraceExporterConfiguration.builder().setServiceName(system))
+            .build())))(_ =>
+        Sync[F].delay(
+          OcAgentTraceExporter.unregister()
+      ))
+      .flatMap(_ => Resource.liftF(entryPoint[F]))
+
+  def entryPoint[F[_]: Sync]: F[EntryPoint[F]] =
+    Sync[F]
+      .delay(Tracing.getTracer)
+      .map { t =>
+        new EntryPoint[F] {
+          override def root(name: String): Resource[F, Span[F]] =
+            Resource
+              .make(
+                Sync[F].delay(t.spanBuilder(name).startSpan())
+              )(s => Sync[F].delay(s.end()))
+              .map(OpenCensusSpan(t, _))
+
+          override def continue(name: String,
+                                kernel: Kernel): Resource[F, Span[F]] =
+            Resource
+              .make(
+                Sync[F].delay {
+                  val ctx = Tracing.getPropagationComponent.getB3Format
+                    .extract(kernel, spanContextGetter)
+                  t.spanBuilderWithRemoteParent(name, ctx).startSpan()
+                }
+              )(s => Sync[F].delay(s.end()))
+              .map(OpenCensusSpan(t, _))
+
+          override def continueOrElseRoot(
+              name: String,
+              kernel: Kernel): Resource[F, Span[F]] =
+            continue(name, kernel) flatMap (
+              _.pure[Resource[F, ?]]
+            ) recoverWith {
+              case _: SpanContextParseException => root(name)
+              case _: NullPointerException =>
+                root(name) // means headers are incomplete or invalid
+            }
+        }
+      }
+
+  private val spanContextGetter: Getter[Kernel] = new Getter[Kernel] {
+    override def get(carrier: Kernel, key: String): String =
+      carrier.toHeaders(key)
+  }
+}

--- a/modules/opencensus/src/main/scala/OpenCensusSpan.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusSpan.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package opencensus
+
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import io.opencensus.trace.propagation.TextFormat.Setter
+import io.opencensus.trace.{AttributeValue, Tracer, Tracing}
+import natchez.TraceValue.{BooleanValue, NumberValue, StringValue}
+
+import scala.collection.mutable
+
+private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
+    tracer: Tracer,
+    span: io.opencensus.trace.Span)
+    extends Span[F] {
+  import OpenCensusSpan._
+
+  override def put(fields: (String, TraceValue)*): F[Unit] =
+    fields.toList.traverse_ {
+      case (k, StringValue(v)) =>
+        Sync[F].delay(
+          span.putAttribute(k, AttributeValue.stringAttributeValue(v)))
+      case (k, NumberValue(v)) =>
+        Sync[F].delay(
+          span.putAttribute(
+            k,
+            AttributeValue.doubleAttributeValue(v.doubleValue())))
+      case (k, BooleanValue(v)) =>
+        Sync[F].delay(
+          span.putAttribute(k, AttributeValue.booleanAttributeValue(v)))
+    }
+
+  override def kernel: F[Kernel] = Sync[F].delay {
+    val headers: mutable.Map[String, String] = mutable.Map.empty[String, String]
+    Tracing.getPropagationComponent.getB3Format
+      .inject(span.getContext, headers, spanContextSetter)
+    Kernel(headers.toMap)
+  }
+
+  override def span(name: String): Resource[F, Span[F]] =
+    Resource
+      .make(
+        Sync[F].delay(
+          tracer
+            .spanBuilderWithExplicitParent(name, span)
+            .startSpan()))(s => Sync[F].delay(s.end()))
+      .map(OpenCensusSpan(tracer, _))
+}
+
+object OpenCensusSpan {
+  private val spanContextSetter = new Setter[mutable.Map[String, String]] {
+    override def put(carrier: mutable.Map[String, String],
+                     key: String,
+                     value: String): Unit = {
+      carrier.put(key, value)
+      ()
+    }
+  }
+}


### PR DESCRIPTION
Loving the project! I just wanted to add support [OpenCensus](https://opencensus.io). I realise there is a [OpenTelemetry](https://opentelemetry.io) coming along which should subsume OpenCensus and OpenTracing, however it's not clear how long it will be until it's usable.

OpenCensus supports pluggable exporters, but I've only added an implementation for the standard agent. Unfortunately it seems the way exporters are configured and resolved is a bit side effecty and uses singletons, so we can't stop someone configuring new exporters outside of a resource.

I'm not sure what formatting standard you were using, so I just used the default scalafmt config. I can add a different config if you'd like?