### PR TITLE
Add support for Lightstep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - git fetch --tags

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is an minimal distributed tracing effect for Cats, inspired by earlier work
 - [Jaeger](https://www.jaegertracing.io/)
 - [Honeycomb](https://www.honeycomb.io/)
 - [OpenCensus](https://www.opencensus.io/)
+- [LightStep](https://lightstep.com)
 
 It supports
 

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,8 @@ lazy val lightstep = project
     name        := "natchez-lightstep",
     description := "Lightstep support for Natchez.",
     libraryDependencies ++= Seq(
-      "com.lightstep.tracer" % "tracer-grpc" % "0.17.2",
+      "com.lightstep.tracer" % "lightstep-tracer-jre" % "0.16.4",
+      "com.lightstep.tracer" % "tracer-grpc"          % "0.17.2",
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,8 @@ lazy val natchez = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(publish / skip := true)
-  .dependsOn(core, jaeger, honeycomb, opencensus, lightstep, examples)
-  .aggregate(core, jaeger, honeycomb, opencensus, lightstep, examples)
+  .dependsOn(core, jaeger, honeycomb, opencensus, lightstep, lightstepGrpc, lightstepHttp, examples)
+  .aggregate(core, jaeger, honeycomb, opencensus, lightstep, lightstepGrpc, lightstepHttp, examples)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -100,19 +100,45 @@ lazy val lightstep = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-lightstep",
-    description := "Lightstep support for Natchez.",
+    publish / skip := true,
+    name           := "natchez-lightstep",
+    description    := "Lightstep support for Natchez.",
     libraryDependencies ++= Seq(
-      "com.lightstep.tracer" % "lightstep-tracer-jre"            % "0.16.4",
+      "com.lightstep.tracer" % "lightstep-tracer-jre" % "0.16.4",
+    )
+  )
+
+lazy val lightstepGrpc = project
+  .in(file("modules/lightstep-grpc"))
+  .dependsOn(lightstep)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-lightstep-grpc",
+    description := "Lightstep gRPC bindings for Natchez.",
+    libraryDependencies ++= Seq(
       "com.lightstep.tracer" % "tracer-grpc"                     % "0.17.2",
       "io.grpc"              % "grpc-netty"                      % "1.20.0",
       "io.netty"             % "netty-tcnative-boringssl-static" % "2.0.25.Final",
     )
   )
 
+lazy val lightstepHttp = project
+  .in(file("modules/lightstep-http"))
+  .dependsOn(lightstep)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-lightstep-http",
+    description := "Lightstep HTTP bindings for Natchez.",
+    libraryDependencies ++= Seq(
+      "com.lightstep.tracer" % "tracer-okhttp" % "0.17.2",
+    )
+  )
+
 lazy val examples = project
   .in(file("modules/examples"))
-  .dependsOn(core, jaeger, honeycomb)
+  .dependsOn(core, jaeger, honeycomb, lightstepHttp)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,8 @@ lazy val natchez = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(publish / skip := true)
-  .dependsOn(core, jaeger, honeycomb, opencensus, examples)
-  .aggregate(core, jaeger, honeycomb, opencensus, examples)
+  .dependsOn(core, jaeger, honeycomb, opencensus, lightstep, examples)
+  .aggregate(core, jaeger, honeycomb, opencensus, lightstep, examples)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -91,6 +91,19 @@ lazy val opencensus = project
     description := "Opencensus support for Natchez.",
     libraryDependencies ++= Seq(
       "io.opencensus" % "opencensus-exporter-trace-ocagent" % "0.20.0",
+    )
+  )
+
+lazy val lightstep = project
+  .in(file("modules/lightstep"))
+  .dependsOn(core)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-lightstep",
+    description := "Lightstep support for Natchez.",
+    libraryDependencies ++= Seq(
+      "com.lightstep.tracer" % "tracer-grpc" % "0.17.2",
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -103,8 +103,10 @@ lazy val lightstep = project
     name        := "natchez-lightstep",
     description := "Lightstep support for Natchez.",
     libraryDependencies ++= Seq(
-      "com.lightstep.tracer" % "lightstep-tracer-jre" % "0.16.4",
-      "com.lightstep.tracer" % "tracer-grpc"          % "0.17.2",
+      "com.lightstep.tracer" % "lightstep-tracer-jre"            % "0.16.4",
+      "com.lightstep.tracer" % "tracer-grpc"                     % "0.17.2",
+      "io.grpc"              % "grpc-netty"                      % "1.22.1",
+      "io.netty"             % "netty-tcnative-boringssl-static" % "2.0.25.Final",
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val lightstep = project
     libraryDependencies ++= Seq(
       "com.lightstep.tracer" % "lightstep-tracer-jre"            % "0.16.4",
       "com.lightstep.tracer" % "tracer-grpc"                     % "0.17.2",
-      "io.grpc"              % "grpc-netty"                      % "1.22.1",
+      "io.grpc"              % "grpc-netty"                      % "1.20.0",
       "io.netty"             % "netty-tcnative-boringssl-static" % "2.0.25.Final",
     )
   )

--- a/modules/examples/src/main/scala/Example.scala
+++ b/modules/examples/src/main/scala/Example.scala
@@ -63,19 +63,21 @@ object Main extends IOApp {
   //     }
   //   }
 
-  // The following would be the entrypoint setup for Lighstep. Note that
+  // The following would be the minimal entrypoint setup for Lighstep. Note that
   // by default examples project uses lighstep HTTP binding. To change that,
   // edit the project dependencies.
-  // def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] = {
-  //   val config = Lightstep.Configuration(
-  //     "<your access token>",
-  //     "<your app's name>",
-  //     "<your collector host>",
-  //     "<your collector protocol>",
-  //     <your collector port>
-  //   )
-  //   Lightstep.entryPoint[F](config)
-  // }
+  // def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
+  //   Lightstep.entryPoint[F] { optionsBuilder =>
+  //     Sync[F].delay {
+  //       optionsBuilder
+  //         .withAccessToken("<your access token>")
+  //         .withComponentName("<your app's name>")
+  //         .withCollectorHost("<your collector host>")
+  //         .withCollectorProtocol("<your collector protocol>")
+  //         .withCollectorPort(<your collector port>)
+  //         .build()
+  //     }
+  //   }
 
   def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
     Jaeger.entryPoint[F]("natchez-example") { c =>

--- a/modules/examples/src/main/scala/Example.scala
+++ b/modules/examples/src/main/scala/Example.scala
@@ -63,6 +63,20 @@ object Main extends IOApp {
   //     }
   //   }
 
+  // The following would be the entrypoint setup for Lighstep. Note that
+  // by default examples project uses lighstep HTTP binding. To change that,
+  // edit the project dependencies.
+  // def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] = {
+  //   val config = Lightstep.Configuration(
+  //     "<your access token>",
+  //     "<your app's name>",
+  //     "<your collector host>",
+  //     "<your collector protocol>",
+  //     <your collector port>
+  //   )
+  //   Lightstep.entryPoint[F](config)
+  // }
+
   def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
     Jaeger.entryPoint[F]("natchez-example") { c =>
       Sync[F].delay {

--- a/modules/lightstep/src/main/scala/Lightstep.scala
+++ b/modules/lightstep/src/main/scala/Lightstep.scala
@@ -5,13 +5,16 @@
 package natchez
 package lightstep
 
-import cats.effect.{ Sync, Resource }
+import cats.effect.{ Resource, Sync }
+import cats.syntax.applicative._
 import com.lightstep.tracer.jre.JRETracer
 import com.lightstep.tracer.shared.Options
 import io.opentracing.Tracer
+import io.opentracing.propagation.{ Format, TextMapAdapter }
+
+import scala.collection.JavaConverters._
 
 object Lightstep {
-  // TODO: use refined types to properly specify the config
   final case class Configuration(
     accessToken: String,
     componentName: String,
@@ -21,8 +24,27 @@ object Lightstep {
   )
 
   def entryPoint[F[_]: Sync](config: Configuration): Resource[F, EntryPoint[F]] =
-    Resource.make(setupTracer(config))(t => Sync[F].delay(t.close())).map { _ =>
-      ???
+    Resource.make(setupTracer(config))(t => Sync[F].delay(t.close())).map { t =>
+      new EntryPoint[F] {
+        override def root(name: String): Resource[F, Span[F]] =
+          Resource
+            .make(Sync[F].delay(t.buildSpan(name).start()))(s => Sync[F].delay(s.finish()))
+            .map(LightstepSpan(t, _))
+
+        override def continue(name: String, kernel: Kernel): Resource[F, Span[F]] =
+          Resource.make(
+            Sync[F].delay {
+              val p = t.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(kernel.toHeaders.asJava))
+              t.buildSpan(name).asChildOf(p).start()
+            }
+          )(s => Sync[F].delay(s.finish())).map(LightstepSpan(t, _))
+
+        override def continueOrElseRoot(name: String, kernel: Kernel): Resource[F, Span[F]] =
+          continue(name, kernel).flatMap {
+            case null => root(name)
+            case a    => a.pure[Resource[F, ?]]
+          }
+      }
     }
 
   private def setupTracer[F[_]: Sync](config: Configuration): F[Tracer] =

--- a/modules/lightstep/src/main/scala/Lightstep.scala
+++ b/modules/lightstep/src/main/scala/Lightstep.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package lightstep
+
+import cats.effect.{ Sync, Resource }
+import com.lightstep.tracer.jre.JRETracer
+import com.lightstep.tracer.shared.Options
+import io.opentracing.Tracer
+
+object Lightstep {
+  // TODO: use refined types to properly specify the config
+  final case class Configuration(
+    accessToken: String,
+    componentName: String,
+    collectorHost: String,
+    collectorProtocol: String,
+    collectorPort: Int
+  )
+
+  def entryPoint[F[_]: Sync](config: Configuration): Resource[F, EntryPoint[F]] =
+    Resource.make(setupTracer(config))(t => Sync[F].delay(t.close())).map { _ =>
+      ???
+    }
+
+  private def setupTracer[F[_]: Sync](config: Configuration): F[Tracer] =
+    Sync[F].delay {
+      val options = new Options.OptionsBuilder()
+        .withAccessToken(config.accessToken)
+        .withComponentName(config.componentName)
+        .withCollectorHost(config.collectorHost)
+        .withCollectorProtocol(config.collectorProtocol)
+        .withCollectorPort(config.collectorPort)
+        .build()
+
+      new JRETracer(options)
+    }
+}

--- a/modules/lightstep/src/main/scala/LightstepSpan.scala
+++ b/modules/lightstep/src/main/scala/LightstepSpan.scala
@@ -6,16 +6,35 @@ package natchez
 package lightstep
 
 import cats.effect.{ Resource, Sync }
+import cats.implicits._
 import io.{ opentracing => ot }
+import io.opentracing.propagation.{ Format, TextMapAdapter }
+
+import scala.collection.JavaConverters._
 
 private[lightstep] final case class LightstepSpan[F[_]: Sync](
   tracer: ot.Tracer,
   span: ot.Span
 ) extends Span[F] {
+  
+  import TraceValue._
 
-  override def kernel: F[Kernel] = ???
+  override def kernel: F[Kernel] =
+    Sync[F].delay {
+      val m = new java.util.HashMap[String, String]
+      tracer.inject(span.context, Format.Builtin.HTTP_HEADERS, new TextMapAdapter(m))
+      Kernel(m.asScala.toMap)
+    }
 
-  override def put(fields: (String, TraceValue)*): F[Unit] = ???
+  override def put(fields: (String, TraceValue)*): F[Unit] =
+    fields.toList.traverse_ {
+      case (k, StringValue(v))  => Sync[F].delay(span.setTag(k, v))
+      case (k, NumberValue(v))  => Sync[F].delay(span.setTag(k, v))
+      case (k, BooleanValue(v)) => Sync[F].delay(span.setTag(k, v))
+    }
 
-  override def span(name: String): Resource[F,Span[F]] = ???
+  override def span(name: String): Resource[F,Span[F]] =
+    Resource
+      .make(Sync[F].delay(tracer.buildSpan(name).asChildOf(span).start()))(s => Sync[F].delay(s.finish()))
+      .map(LightstepSpan(tracer, _))
 }

--- a/modules/lightstep/src/main/scala/LightstepSpan.scala
+++ b/modules/lightstep/src/main/scala/LightstepSpan.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package lightstep
+
+import cats.effect.{ Resource, Sync }
+import io.{ opentracing => ot }
+
+private[lightstep] final case class LightstepSpan[F[_]: Sync](
+  tracer: ot.Tracer,
+  span: ot.Span
+) extends Span[F] {
+
+  override def kernel: F[Kernel] = ???
+
+  override def put(fields: (String, TraceValue)*): F[Unit] = ???
+
+  override def span(name: String): Resource[F,Span[F]] = ???
+}


### PR DESCRIPTION
### Summary

- Introduced lighstep bindings for both gRPC and HTTP.
- Fixed the configurable parameters to the ones enlisted [here](https://github.com/lightstep/lightstep-tracer-java/tree/master/lightstep-tracer-jre-bundle#parameters).

### Remarks

- Configuration can be made more specific via [refined](https://github.com/fthomas/refined).
- `JaegerSpan` and `LightstepSpan` are the same, while entrypoints are very similar. Should they be kept as they are or extracted somewhere?
- `oraclejdk8` has been replaced with `openjdk8` due to TravisCI failures as described in [this thread](https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766)
