### PR TITLE
Fix lightstep project dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,6 @@ lazy val lightstep = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    publish / skip := true,
     name           := "natchez-lightstep",
     description    := "Lightstep support for Natchez.",
     libraryDependencies ++= Seq(

--- a/modules/examples/src/main/scala/Example.scala
+++ b/modules/examples/src/main/scala/Example.scala
@@ -67,15 +67,17 @@ object Main extends IOApp {
   // by default examples project uses lighstep HTTP binding. To change that,
   // edit the project dependencies.
   // def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
-  //   Lightstep.entryPoint[F] { optionsBuilder =>
+  //   Lightstep.entryPoint[F] { ob =>
   //     Sync[F].delay {
-  //       optionsBuilder
+  //       val options = ob
   //         .withAccessToken("<your access token>")
   //         .withComponentName("<your app's name>")
   //         .withCollectorHost("<your collector host>")
   //         .withCollectorProtocol("<your collector protocol>")
   //         .withCollectorPort(<your collector port>)
   //         .build()
+  //       
+  //       new JRETracer(options)
   //     }
   //   }
 


### PR DESCRIPTION
Lightstep bindings were added in #13, but their "root" (i.e. project `lightstep`) wasn't published, causing the following error on use-site:

```
[error] sbt.librarymanagement.ResolveException: unresolved dependency: org.tpolecat#natchez-lightstep_2.12;0.0.7: not found
```

This PR fixes the aforemenetioned error by publishing project `lightstep`.