### PR TITLE
logger-based tracing support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,8 @@ lazy val log = project
     name        := "natchez-log",
     description := "Logging bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core" % "0.11.1"
+      "io.circe"          %% "circe-core"    % "0.11.1",
+      "io.chrisdavenport" %% "log4cats-core" % "1.0.0",
     )
   )
 
@@ -162,6 +163,7 @@ lazy val examples = project
     name           := "natchez-examples",
     description    := "Example programs for Natchez.",
     libraryDependencies ++= Seq(
-      "org.tpolecat"    %% "skunk-core"    % "0.0.3+36-5e8dc7c3-SNAPSHOT"
+      "org.tpolecat"      %% "skunk-core"     % "0.0.3+36-5e8dc7c3-SNAPSHOT",
+      "io.chrisdavenport" %% "log4cats-slf4j" % "1.0.0",
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,10 @@ lazy val commonSettings = Seq(
   ),
   addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10"),
 
+  // Blah
+  resolvers +=
+    "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+
 )
 
 lazy val natchez = project
@@ -135,9 +139,22 @@ lazy val lightstepHttp = project
     )
   )
 
+lazy val log = project
+  .in(file("modules/log"))
+  .dependsOn(core)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-log",
+    description := "Logging bindings for Natchez.",
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core" % "0.11.1"
+    )
+  )
+
 lazy val examples = project
   .in(file("modules/examples"))
-  .dependsOn(core, jaeger, honeycomb, lightstepHttp)
+  .dependsOn(core, jaeger, honeycomb, lightstepHttp, log)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
@@ -145,6 +162,6 @@ lazy val examples = project
     name           := "natchez-examples",
     description    := "Example programs for Natchez.",
     libraryDependencies ++= Seq(
-      "org.tpolecat"    %% "skunk-core"    % "0.0.3"
+      "org.tpolecat"    %% "skunk-core"    % "0.0.3+36-5e8dc7c3-SNAPSHOT"
     )
   )

--- a/modules/examples/src/main/scala/Example.scala
+++ b/modules/examples/src/main/scala/Example.scala
@@ -12,13 +12,12 @@ import natchez._
 import skunk._
 import skunk.codec.all._
 import skunk.implicits._
-import natchez.jaeger.Jaeger
-import io.jaegertracing.Configuration._
+import natchez.log.Log
 
 object Main extends IOApp {
 
   // A skunk session resource
-  def session[F[_]: Concurrent: ContextShift]: Resource[F, Session[F]] =
+  def session[F[_]: Concurrent: ContextShift: Trace]: Resource[F, Session[F]] =
     Session.single(
       host     = "localhost",
       user     = "postgres",
@@ -76,19 +75,23 @@ object Main extends IOApp {
   //         .withCollectorProtocol("<your collector protocol>")
   //         .withCollectorPort(<your collector port>)
   //         .build()
-  //       
+  //
   //       new JRETracer(options)
   //     }
   //   }
 
+  // Jaeger
+  // def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
+  //   Jaeger.entryPoint[F]("natchez-example") { c =>
+  //     Sync[F].delay {
+  //       c.withSampler(SamplerConfiguration.fromEnv)
+  //        .withReporter(ReporterConfiguration.fromEnv)
+  //        .getTracer
+  //     }
+  //   }
+
   def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
-    Jaeger.entryPoint[F]("natchez-example") { c =>
-      Sync[F].delay {
-        c.withSampler(SamplerConfiguration.fromEnv)
-         .withReporter(ReporterConfiguration.fromEnv)
-         .getTracer
-      }
-    }
+    Log.entryPoint[F]("foo").pure[Resource[F, ?]]
 
   def run(args: List[String]): IO[ExitCode] =
     entryPoint[IO].use { ep =>

--- a/modules/examples/src/main/scala/Example.scala
+++ b/modules/examples/src/main/scala/Example.scala
@@ -13,6 +13,8 @@ import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 import natchez.log.Log
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 object Main extends IOApp {
 
@@ -90,15 +92,17 @@ object Main extends IOApp {
   //     }
   //   }
 
-  def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
+  def entryPoint[F[_]: Sync: Logger]: Resource[F, EntryPoint[F]] =
     Log.entryPoint[F]("foo").pure[Resource[F, ?]]
 
-  def run(args: List[String]): IO[ExitCode] =
+  def run(args: List[String]): IO[ExitCode] = {
+    implicit val log = Slf4jLogger.getLogger[IO]
     entryPoint[IO].use { ep =>
       ep.root("root").use { span =>
         runF[Kleisli[IO, Span[IO], ?]].run(span)
       }
     } as ExitCode.Success
+  }
 
 }
 

--- a/modules/log/README.md
+++ b/modules/log/README.md
@@ -1,0 +1,8 @@
+
+# Log Handler
+
+This is a simple Natchez back-end that prints traces to a logger, formatted as a JSON structure.
+
+- Continued traces have correct parent span/trace ids but otherwise distributed tracing is unsupported (because there is no span collector).
+- Spans are displayed as JSON objects where span fields are object properties. A special property called `children` contains a list of child spans.
+

--- a/modules/log/src/main/scala/Log.scala
+++ b/modules/log/src/main/scala/Log.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package log
+
+import cats.effect.{ Resource, Sync }
+import cats.implicits._
+
+object Log {
+
+  def entryPoint[F[_]: Sync](
+    service: String,
+  ): EntryPoint[F] =
+    new EntryPoint[F] {
+
+      def make(span: F[LogSpan[F]]): Resource[F, Span[F]] =
+        Resource.makeCase(span)(LogSpan.finish).widen
+
+      def continue(name: String, kernel: Kernel): Resource[F,Span[F]] =
+        make(LogSpan.fromKernel(service, name, kernel))
+
+      def continueOrElseRoot(name: String, kernel: Kernel): Resource[F,Span[F]] =
+        make(LogSpan.fromKernelOrElseRoot(service, name, kernel))
+
+      def root(name: String): Resource[F,Span[F]] =
+        make(LogSpan.root(service, name))
+
+    }
+
+
+}

--- a/modules/log/src/main/scala/Log.scala
+++ b/modules/log/src/main/scala/Log.scala
@@ -7,10 +7,11 @@ package log
 
 import cats.effect.{ Resource, Sync }
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 
 object Log {
 
-  def entryPoint[F[_]: Sync](
+  def entryPoint[F[_]: Sync: Logger](
     service: String,
   ): EntryPoint[F] =
     new EntryPoint[F] {

--- a/modules/log/src/main/scala/LogSpan.scala
+++ b/modules/log/src/main/scala/LogSpan.scala
@@ -1,0 +1,204 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez.log
+
+import cats.effect.concurrent.Ref
+import cats.effect._
+import cats.effect.ExitCase._
+import cats.implicits._
+import java.time.Instant
+import java.util.UUID
+import natchez._
+import natchez.TraceValue._
+import io.circe.Json
+import io.circe.Encoder
+import io.circe.syntax._
+import io.circe.JsonObject
+
+private[log] final case class LogSpan[F[_]: Sync](
+  service:   String,
+  name:      String,
+  spanId:    UUID,
+  parent:  Option[Either[UUID, LogSpan[F]]],
+  traceId:   UUID,
+  timestamp: Instant,
+  fields:    Ref[F, Map[String, Json]],
+  children:  Ref[F, List[JsonObject]]
+) extends Span[F] {
+  import LogSpan._
+
+  def parentId: Option[UUID] =
+    parent.map(_.fold(identity, _.traceId))
+
+  def get(key: String): F[Option[Json]] =
+    fields.get.map(_.get(key))
+
+  def kernel: F[Kernel] =
+    Kernel(Map(
+      Headers.TraceId -> traceId.toString,
+      Headers.SpanId  -> spanId.toString
+    )).pure[F]
+
+  def put(fields: (String, TraceValue)*): F[Unit] =
+    putAny(fields.map { case (k, v) => (k -> v.asJson) }: _*)
+
+  def putAny(fields: (String, Json)*): F[Unit] =
+    this.fields.update(_ ++ fields.toMap)
+
+  def span(label: String): Resource[F, Span[F]] =
+    Resource.makeCase(LogSpan.child(this, label))(LogSpan.finish[F]).widen
+
+  def json(finish: Instant, exitCase: ExitCase[Throwable]): F[JsonObject] =
+    (fields.get, children.get).mapN { (fs, cs) =>
+
+      // Assemble our JSON object such that the Natchez fields always come first, in the same
+      // order, followed by error fields (if any), followed by span fields.
+
+      def exitFields(ex: Throwable): List[(String, Json)] =
+        List(
+          "exit.case"             -> "error".asJson,
+          "exit.error.class"      -> ex.getClass.getName.asJson,
+          "exit.error.message"    -> ex.getMessage.asJson,
+          "exit.error.stackTrace" -> ex.getStackTrace.map(_.toString).asJson,
+        )
+
+      val fields: List[(String, Json)] =
+        List(
+          "name"            -> name.asJson,
+          "service"         -> service.asJson,
+          "timestamp"       -> timestamp.asJson,
+          "duration_ms"     -> (finish.toEpochMilli - timestamp.toEpochMilli).asJson,
+          "trace.span_id"   -> spanId.asJson,
+          "trace.parent_id" -> parentId.asJson,
+          "trace.trace_id"  -> traceId.asJson,
+        ) ++ {
+          exitCase match {
+            case Completed                  => List("exit.case" -> "completed".asJson)
+            case Canceled                   => List("exit.case" -> "canceled".asJson)
+            case Error(ex: Fields) => exitFields(ex) ++ ex.fields.mapValues(_.asJson).toList
+            case Error(ex)         => exitFields(ex)
+          }
+        } ++ fs ++ List("children" -> cs.reverse.map(Json.fromJsonObject).asJson)
+
+      JsonObject.fromIterable(fields)
+
+    }
+
+}
+
+private[log] object LogSpan {
+
+  implicit val EncodeTraceValue: Encoder[TraceValue] =
+    Encoder.instance {
+      case StringValue(s)                       => s.asJson
+      case BooleanValue(b)                      => b.asJson
+      case NumberValue(n: java.lang.Byte)       => n.asJson
+      case NumberValue(n: java.lang.Short)      => n.asJson
+      case NumberValue(n: java.lang.Integer)    => n.asJson
+      case NumberValue(n: java.lang.Long)       => n.asJson
+      case NumberValue(n: java.lang.Float)      => n.asJson
+      case NumberValue(n: java.lang.Double)     => n.asJson
+      case NumberValue(n: java.math.BigDecimal) => n.asJson
+      case NumberValue(n: java.math.BigInteger) => n.asJson
+      case NumberValue(n: BigDecimal)           => n.asJson
+      case NumberValue(n: BigInt)               => n.asJson
+      case NumberValue(n)                       => n.doubleValue.asJson
+    }
+
+  object Headers {
+    val TraceId       = "X-Natchez-Trace-Id"
+    val SpanId        = "X-Natchez-Parent-Span-Id"
+  }
+
+  private def uuid[F[_]: Sync]: F[UUID] =
+    Sync[F].delay(UUID.randomUUID)
+
+  private def now[F[_]: Sync]: F[Instant] =
+    Sync[F].delay(Instant.now)
+
+  def finish[F[_]: Sync]: (LogSpan[F], ExitCase[Throwable]) => F[Unit] = { (span, exitCase) =>
+    for {
+      n  <- now
+      j  <- span.json(n, exitCase)
+      _  <- span.parent match {
+              case None | Some(Left(_)) => Sync[F].delay(java.util.logging.Logger.getLogger("natchez").info(Json.fromJsonObject(j).spaces2))
+              case Some(Right(s)) => s.children.update(j :: _)
+            }
+    } yield ()
+  }
+
+  def child[F[_]: Sync](
+    parent: LogSpan[F],
+    name:   String
+  ): F[LogSpan[F]] =
+    for {
+      spanId    <- uuid[F]
+      timestamp <- now[F]
+      fields    <- Ref[F].of(Map.empty[String, Json])
+      children  <- Ref[F].of(List.empty[JsonObject])
+    } yield LogSpan(
+      service   = parent.service,
+      name      = name,
+      spanId    = spanId,
+      parent    = Some(Right(parent)),
+      traceId   = parent.traceId,
+      timestamp = timestamp,
+      fields    = fields,
+      children  = children
+    )
+
+  def root[F[_]: Sync](
+    service: String,
+    name:    String
+  ): F[LogSpan[F]] =
+    for {
+      spanId    <- uuid[F]
+      traceId   <- uuid[F]
+      timestamp <- now[F]
+      fields    <- Ref[F].of(Map.empty[String, Json])
+      children  <- Ref[F].of(List.empty[JsonObject])
+    } yield LogSpan(
+      service   = service,
+      name      = name,
+      spanId    = spanId,
+      parent    = None,
+      traceId   = traceId,
+      timestamp = timestamp,
+      fields    = fields,
+      children  = children
+    )
+
+  def fromKernel[F[_]](
+    service: String,
+    name:    String,
+    kernel:  Kernel
+  )(implicit ev: Sync[F]): F[LogSpan[F]] =
+    for {
+      traceId  <- ev.catchNonFatal(UUID.fromString(kernel.toHeaders(Headers.TraceId)))
+      parentId <- ev.catchNonFatal(UUID.fromString(kernel.toHeaders(Headers.SpanId)))
+      spanId    <- uuid[F]
+      timestamp <- now[F]
+      fields    <- Ref[F].of(Map.empty[String, Json])
+      children  <- Ref[F].of(List.empty[JsonObject])
+    } yield LogSpan(
+      service   = service,
+      name      = name,
+      spanId    = spanId,
+      parent    = Some(Left(parentId)),
+      traceId   = traceId,
+      timestamp = timestamp,
+      fields    = fields,
+      children  = children
+    )
+
+  def fromKernelOrElseRoot[F[_]](
+    service: String,
+    name:    String,
+    kernel:  Kernel
+  )(implicit ev: Sync[F]): F[LogSpan[F]] =
+    fromKernel(service, name, kernel).recoverWith {
+      case _: NoSuchElementException => root(service, name)
+    }
+}


### PR DESCRIPTION
This gives you `(Sync[F], Log[F]) => Trace[F]` so you can "trace" to a Log4Cats logger if you want to. It dumps the trace data as a hunk of Json. Not ideal and not particularly performant but it can be useful for debugging and prototyping.