### PR TITLE
Semigroup/monoid instances

### DIFF
--- a/modules/core/src/main/scala/Kernel.scala
+++ b/modules/core/src/main/scala/Kernel.scala
@@ -4,9 +4,20 @@
 
 package natchez
 
+import cats.kernel.Monoid
+
 /**
  * An opaque hunk of data that can we can hand off to another system (in the form of HTTP headers),
  * which can then create new spans as children of this one. By this mechanism we allow our trace
  * to span remote calls.
  */
 final case class Kernel(toHeaders: Map[String, String])
+
+object Kernel {
+  implicit def kernelMonoid: Monoid[Kernel] =
+    new Monoid[Kernel] {
+      override def empty: Kernel = Kernel(Map.empty)
+
+      override def combine(x: Kernel, y: Kernel): Kernel = Kernel(x.toHeaders ++ y.toHeaders)
+    }
+}

--- a/modules/core/src/main/scala/Kernel.scala
+++ b/modules/core/src/main/scala/Kernel.scala
@@ -5,19 +5,33 @@
 package natchez
 
 import cats.kernel.Monoid
+import natchez.Kernel.HeaderKey
 
 /**
- * An opaque hunk of data that can we can hand off to another system (in the form of HTTP headers),
- * which can then create new spans as children of this one. By this mechanism we allow our trace
- * to span remote calls.
- */
-final case class Kernel(toHeaders: Map[String, String])
+  * An opaque hunk of data that can we can hand off to another system (in the form of HTTP headers),
+  * which can then create new spans as children of this one. By this mechanism we allow our trace
+  * to span remote calls.
+  */
+final case class Kernel(keyedHeaders: Map[HeaderKey, String]) {
+  def toHeaders(selector: PartialFunction[HeaderKey, String]): Map[String, String] = keyedHeaders.flatMap {
+    case (k, v) => selector.lift(k).map(_ -> v)
+  }
+}
 
 object Kernel {
+  trait HeaderKey {
+    def key: String
+  }
+
+  def fromHeaders(headers: Map[String, String])(
+      toHeaderKey: String => HeaderKey) =
+    Kernel(headers.map { case (k, v) => toHeaderKey(k) -> v })
+
   implicit def kernelMonoid: Monoid[Kernel] =
     new Monoid[Kernel] {
       override def empty: Kernel = Kernel(Map.empty)
 
-      override def combine(x: Kernel, y: Kernel): Kernel = Kernel(x.toHeaders ++ y.toHeaders)
+      override def combine(x: Kernel, y: Kernel): Kernel =
+        Kernel(x.keyedHeaders ++ y.keyedHeaders)
     }
 }

--- a/modules/honeycomb/src/main/scala/HoneycombHeaderKey.scala
+++ b/modules/honeycomb/src/main/scala/HoneycombHeaderKey.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package honeycomb
+
+import natchez.Kernel.HeaderKey
+
+private[honeycomb] final case class HoneycombHeaderKey(key: String) extends HeaderKey

--- a/modules/honeycomb/src/main/scala/HoneycombSpan.scala
+++ b/modules/honeycomb/src/main/scala/HoneycombSpan.scala
@@ -45,8 +45,8 @@ private[honeycomb] final case class HoneycombSpan[F[_]: Sync](
 private[honeycomb] object HoneycombSpan {
 
   object Headers {
-    val TraceId       = "X-Natchez-Trace-Id"
-    val SpanId        = "X-Natchez-Parent-Span-Id"
+    val TraceId       = HoneycombHeaderKey("X-Natchez-Trace-Id")
+    val SpanId        = HoneycombHeaderKey("X-Natchez-Parent-Span-Id")
   }
 
   private def uuid[F[_]: Sync]: F[UUID] =
@@ -129,8 +129,8 @@ private[honeycomb] object HoneycombSpan {
     kernel: Kernel
   )(implicit ev: Sync[F]): F[HoneycombSpan[F]] =
     for {
-      traceId  <- ev.catchNonFatal(UUID.fromString(kernel.toHeaders(Headers.TraceId)))
-      parentId <- ev.catchNonFatal(UUID.fromString(kernel.toHeaders(Headers.SpanId)))
+      traceId  <- ev.catchNonFatal(UUID.fromString(kernel.keyedHeaders(Headers.TraceId)))
+      parentId <- ev.catchNonFatal(UUID.fromString(kernel.keyedHeaders(Headers.SpanId)))
       spanId    <- uuid[F]
       timestamp <- now[F]
       fields    <- Ref[F].of(Map.empty[String, TraceValue])

--- a/modules/jaeger/src/main/scala/JaegerHeaderKey.scala
+++ b/modules/jaeger/src/main/scala/JaegerHeaderKey.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package jaeger
+
+import natchez.Kernel.HeaderKey
+
+private[jaeger] final case class JaegerHeaderKey(key: String) extends HeaderKey

--- a/modules/jaeger/src/main/scala/JaegerSpan.scala
+++ b/modules/jaeger/src/main/scala/JaegerSpan.scala
@@ -5,7 +5,7 @@
 package natchez
 package jaeger
 
-import io.{ opentracing => ot }
+import io.{opentracing => ot}
 import cats.effect.Sync
 import cats.effect.Resource
 import cats.implicits._
@@ -28,7 +28,7 @@ private[jaeger] final case class JaegerSpan[F[_]: Sync](
         Format.Builtin.HTTP_HEADERS,
         new TextMapAdapter(m)
       )
-      Kernel(m.asScala.toMap)
+      Kernel.fromHeaders(m.asScala.toMap)(JaegerHeaderKey)
     }
 
   def put(fields: (String, TraceValue)*): F[Unit] =

--- a/modules/jaeger/src/main/scala/JaegerTracer.scala
+++ b/modules/jaeger/src/main/scala/JaegerTracer.scala
@@ -32,7 +32,7 @@ object Jaeger {
               Sync[F].delay {
                 val p = t.extract(
                   Format.Builtin.HTTP_HEADERS,
-                  new TextMapAdapter(kernel.toHeaders.asJava)
+                  new TextMapAdapter(kernel.toHeaders { case JaegerHeaderKey(k) => k }.asJava)
                 )
                 t.buildSpan(name).asChildOf(p).start()
               }

--- a/modules/lightstep/src/main/scala/Lightstep.scala
+++ b/modules/lightstep/src/main/scala/Lightstep.scala
@@ -25,7 +25,8 @@ object Lightstep {
         override def continue(name: String, kernel: Kernel): Resource[F, Span[F]] =
           Resource.make(
             Sync[F].delay {
-              val p = t.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(kernel.toHeaders.asJava))
+              val p = t.extract(Format.Builtin.HTTP_HEADERS,
+                new TextMapAdapter(kernel.toHeaders { case LightstepHeaderKey(k) => k }.asJava))
               t.buildSpan(name).asChildOf(p).start()
             }
           )(s => Sync[F].delay(s.finish())).map(LightstepSpan(t, _))

--- a/modules/lightstep/src/main/scala/LightstepHeaderKey.scala
+++ b/modules/lightstep/src/main/scala/LightstepHeaderKey.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package lightstep
+
+import natchez.Kernel.HeaderKey
+
+private[lightstep] final case class LightstepHeaderKey(key: String) extends HeaderKey

--- a/modules/lightstep/src/main/scala/LightstepSpan.scala
+++ b/modules/lightstep/src/main/scala/LightstepSpan.scala
@@ -23,7 +23,7 @@ private[lightstep] final case class LightstepSpan[F[_]: Sync](
     Sync[F].delay {
       val m = new java.util.HashMap[String, String]
       tracer.inject(span.context, Format.Builtin.HTTP_HEADERS, new TextMapAdapter(m))
-      Kernel(m.asScala.toMap)
+      Kernel.fromHeaders(m.asScala.toMap)(LightstepHeaderKey)
     }
 
   override def put(fields: (String, TraceValue)*): F[Unit] =

--- a/modules/log/src/main/scala/LogHeaderKey.scala
+++ b/modules/log/src/main/scala/LogHeaderKey.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package log
+
+import natchez.Kernel.HeaderKey
+
+private[log] final case class LogHeaderKey(key: String) extends HeaderKey

--- a/modules/log/src/main/scala/LogSpan.scala
+++ b/modules/log/src/main/scala/LogSpan.scala
@@ -109,8 +109,8 @@ private[log] object LogSpan {
     }
 
   object Headers {
-    val TraceId       = "X-Natchez-Trace-Id"
-    val SpanId        = "X-Natchez-Parent-Span-Id"
+    val TraceId       = LogHeaderKey("X-Natchez-Trace-Id")
+    val SpanId        = LogHeaderKey("X-Natchez-Parent-Span-Id")
   }
 
   private def uuid[F[_]: Sync]: F[UUID] =
@@ -178,8 +178,8 @@ private[log] object LogSpan {
     kernel:  Kernel
   ): F[LogSpan[F]] =
     for {
-      traceId  <- Sync[F].catchNonFatal(UUID.fromString(kernel.toHeaders(Headers.TraceId)))
-      parentId <- Sync[F].catchNonFatal(UUID.fromString(kernel.toHeaders(Headers.SpanId)))
+      traceId  <- Sync[F].catchNonFatal(UUID.fromString(kernel.keyedHeaders(Headers.TraceId)))
+      parentId <- Sync[F].catchNonFatal(UUID.fromString(kernel.keyedHeaders(Headers.SpanId)))
       spanId    <- uuid[F]
       timestamp <- now[F]
       fields    <- Ref[F].of(Map.empty[String, Json])

--- a/modules/opencensus/src/main/scala/OpenCensus.scala
+++ b/modules/opencensus/src/main/scala/OpenCensus.scala
@@ -50,8 +50,9 @@ object OpenCensus {
             Resource
               .make(
                 Sync[F].delay {
+                  val headers = kernel.toHeaders { case OpenCensusHeaderKey(k) => k }
                   val ctx = Tracing.getPropagationComponent.getB3Format
-                    .extract(kernel, spanContextGetter)
+                    .extract(headers, spanContextGetter)
                   t.spanBuilderWithRemoteParent(name, ctx).startSpan()
                 }
               )(s => Sync[F].delay(s.end()))
@@ -72,8 +73,8 @@ object OpenCensus {
         }
       }
 
-  private val spanContextGetter: Getter[Kernel] = new Getter[Kernel] {
-    override def get(carrier: Kernel, key: String): String =
-      carrier.toHeaders(key)
+  private val spanContextGetter: Getter[Map[String, String]] = new Getter[Map[String, String]] {
+    override def get(carrier: Map[String, String], key: String): String =
+      carrier(key)
   }
 }

--- a/modules/opencensus/src/main/scala/OpenCensusHeaderKey.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusHeaderKey.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package opencensus
+
+import natchez.Kernel.HeaderKey
+
+private[opencensus] final case class OpenCensusHeaderKey(key: String) extends HeaderKey

--- a/modules/opencensus/src/main/scala/OpenCensusSpan.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusSpan.scala
@@ -38,7 +38,7 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
     val headers: mutable.Map[String, String] = mutable.Map.empty[String, String]
     Tracing.getPropagationComponent.getB3Format
       .inject(span.getContext, headers, spanContextSetter)
-    Kernel(headers.toMap)
+    Kernel.fromHeaders(headers.toMap)(OpenCensusHeaderKey)
   }
 
   override def span(name: String): Resource[F, Span[F]] =


### PR DESCRIPTION
I've add some instances for kernel, span, and entrypoint. The motivation for doing so is to allow combination of different tracers, for example you may want to combine the logger with lightstep.

I haven't added laws yet, but am happy to do so if you like the idea of doing things this way.