### PR TITLE
Use exit cases to mark error details on opencensus span

### DIFF
--- a/modules/opencensus/src/main/scala/OpenCensusSpan.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusSpan.scala
@@ -5,7 +5,9 @@
 package natchez
 package opencensus
 
-import cats.effect.{Resource, Sync}
+import cats.effect._
+import cats.effect.ExitCase.Canceled
+import cats.effect.ExitCase.Completed
 import cats.implicits._
 import io.opencensus.trace.propagation.TextFormat.Setter
 import io.opencensus.trace.{AttributeValue, Tracer, Tracing}
@@ -17,6 +19,7 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
     tracer: Tracer,
     span: io.opencensus.trace.Span)
     extends Span[F] {
+
   import OpenCensusSpan._
 
   override def put(fields: (String, TraceValue)*): F[Unit] =
@@ -43,12 +46,7 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
 
   override def span(name: String): Resource[F, Span[F]] =
     Resource
-      .make(
-        Sync[F].delay(
-          tracer
-            .spanBuilderWithExplicitParent(name, span)
-            .startSpan()))(s => Sync[F].delay(s.end()))
-      .map(OpenCensusSpan(tracer, _))
+      .makeCase(OpenCensusSpan.child(this, name))(OpenCensusSpan.finish).widen
 }
 
 object OpenCensusSpan {
@@ -59,5 +57,37 @@ object OpenCensusSpan {
       carrier.put(key, value)
       ()
     }
+  }
+
+  def child[F[_]: Sync](
+    parent: OpenCensusSpan[F],
+    name:   String
+  ): F[OpenCensusSpan[F]] =
+    Sync[F].delay(
+      parent
+        .tracer
+        .spanBuilderWithExplicitParent(name, parent.span)
+        .startSpan()
+    ).map(OpenCensusSpan(parent.tracer, _))
+
+  def finish[F[_]: Sync]: (OpenCensusSpan[F], ExitCase[Throwable]) => F[Unit] = { (outer, exitCase) =>
+    for {
+      // collect error details, if any
+      _  <- exitCase.some.collect {
+              case ExitCase.Error(t: Fields) => t.fields.toList
+            }.traverse(outer.put)
+      _  <- Sync[F].delay {
+              exitCase match {
+                case Completed          => outer.span.setStatus(io.opencensus.trace.Status.OK)
+                case Canceled           => outer.span.setStatus(io.opencensus.trace.Status.CANCELLED)
+                case ExitCase.Error(ex) =>
+                  outer.span.putAttribute("error.stack", AttributeValue.stringAttributeValue(ex.getMessage))
+                  outer.span.putAttribute("error.msg",   AttributeValue.stringAttributeValue(ex.getStackTrace.mkString("\n")))
+
+                  outer.span.setStatus(io.opencensus.trace.Status.INTERNAL.withDescription(ex.getMessage))
+              }
+            }
+      _  <- Sync[F].delay(outer.span.end())
+    } yield ()
   }
 }


### PR DESCRIPTION
There are some fields on the open census span which are useful for error reporting.  This PR follows the HoneyComb span and uses the ExitCase from the effect within a span to determine whether the span failed.  The status is updated accordingly:
 - Ok if the span completed
- Cancelled if the span was cancelled etc

If the effect failed, then additional information such as the stack trace is captured.