### PR TITLE
Refactor out a generic OpenTracing span/tracer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,8 @@ lazy val natchez = project
     crossScalaVersions := Nil,
     publish / skip     := true
   )
-  .dependsOn(core, jaeger, honeycomb, opencensus, lightstep, lightstepGrpc, lightstepHttp, examples)
-  .aggregate(core, jaeger, honeycomb, opencensus, lightstep, lightstepGrpc, lightstepHttp, examples)
+  .dependsOn(core, jaeger, honeycomb, opencensus, opentracing, lightstep, lightstepGrpc, lightstepHttp, examples)
+  .aggregate(core, jaeger, honeycomb, opencensus, opentracing, lightstep, lightstepGrpc, lightstepHttp, examples)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -65,9 +65,23 @@ lazy val core = project
     )
   )
 
+lazy val opentracing = project
+  .in(file("modules/opentracing"))
+  .dependsOn(core)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-opentracing-core",
+    description := "OpenTracing support for Natchez.",
+    libraryDependencies ++= Seq(
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.3",
+      "io.opentracing" % "opentracing-api" % "0.33.0",
+    )
+  )
+
 lazy val jaeger = project
   .in(file("modules/jaeger"))
-  .dependsOn(core)
+  .dependsOn(core, opentracing)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(

--- a/modules/jaeger/src/main/scala/JaegerTracer.scala
+++ b/modules/jaeger/src/main/scala/JaegerTracer.scala
@@ -5,54 +5,17 @@
 package natchez
 package jaeger
 
-import cats.effect._
-import cats.implicits._
+import cats.effect.{Resource, Sync}
+import cats.syntax.functor._
 import io.jaegertracing.Configuration
-import io.jaegertracing.internal.exceptions.UnsupportedFormatException
-import io.jaegertracing.internal.{ JaegerTracer => NativeJaegerTracer }
-import io.opentracing.propagation.Format
-import io.opentracing.propagation.TextMapAdapter
-
-import scala.jdk.CollectionConverters._
+import io.jaegertracing.internal.{JaegerTracer => NativeJaegerTracer}
+import natchez.opentracing.OTTracer
 
 object Jaeger {
 
   def entryPoint[F[_]: Sync](system: String)(
     configure: Configuration => F[NativeJaegerTracer]
   ): Resource[F, EntryPoint[F]] =
-    Resource.make(
-      Sync[F].delay(
-        new Configuration(system)).flatMap(configure))(
-        c => Sync[F].delay(c.close)
-      ).map { t =>
-        new EntryPoint[F] {
-
-          def continue(name: String, kernel: Kernel): Resource[F,Span[F]] =
-            Resource.make(
-              Sync[F].delay {
-                val p = t.extract(
-                  Format.Builtin.HTTP_HEADERS,
-                  new TextMapAdapter(kernel.toHeaders.asJava)
-                )
-                t.buildSpan(name).asChildOf(p).start()
-              }
-            )(s => Sync[F].delay(s.finish)).map(JaegerSpan(t, _))
-
-          def root(name: String): Resource[F,Span[F]] =
-            Resource.make(
-              Sync[F].delay(t.buildSpan(name).start()))(
-              s => Sync[F].delay(s.finish)
-            ).map(JaegerSpan(t, _))
-
-          def continueOrElseRoot(name: String, kernel: Kernel): Resource[F,Span[F]] =
-            continue(name, kernel) flatMap {
-              case null => root(name) // hurr, means headers are incomplete or invalid
-              case a    => a.pure[Resource[F, ?]]
-            } recoverWith {
-              case _: UnsupportedFormatException => root(name)
-            }
-
-        }
-      }
+      OTTracer.entryPoint(configure(new Configuration(system)).widen)
 
 }

--- a/modules/opentracing/src/main/scala/OTSpan.scala
+++ b/modules/opentracing/src/main/scala/OTSpan.scala
@@ -36,6 +36,9 @@ private[opentracing] final case class OTSpan[F[_] : Sync](tracer: ot.Tracer,
     }
 
   def span(name: String): Resource[F, Span[F]] =
-    makeSpan(tracer)(Sync[F].delay(tracer.buildSpan(name).asChildOf(span).start))
-
+    makeSpan(tracer)(Sync[F].delay {
+      val newSpan: ot.Span = tracer.buildSpan(name).asChildOf(span).start()
+      tracer.scopeManager().activate(newSpan)
+      newSpan
+    })
 }

--- a/modules/opentracing/src/main/scala/OTTracer.scala
+++ b/modules/opentracing/src/main/scala/OTTracer.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package opentracing
+
+import cats.Applicative
+import cats.effect.{ExitCase, Resource, Sync}
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import cats.syntax.applicativeError._
+import io.opentracing.log.Fields
+import io.{opentracing => ot}
+import io.opentracing.propagation.{Format, TextMapAdapter}
+
+import scala.jdk.CollectionConverters._
+
+object OTTracer {
+
+  private [opentracing] def makeSpan[F[_] : Sync](t: ot.Tracer)(acquireSpan: F[ot.Span]): Resource[F, Span[F]] =
+    Resource.makeCase(acquireSpan)(finishSpan(t)).map(OTSpan(t, _))
+
+  private def finishSpan[F[_] : Sync](t: ot.Tracer): (ot.Span, ExitCase[Throwable]) => F[Unit] =
+    (s, exitCase) => {
+      def attachPossibleException: ExitCase[Throwable] => F[Unit] = {
+        case ExitCase.Error(ex) =>
+          val map: java.util.Map[String, Throwable] = new java.util.HashMap[String, Throwable]
+          map.put(Fields.ERROR_OBJECT, ex)
+
+          Sync[F].delay(s.log(map)).void
+        case _ => Applicative[F].unit
+      }
+
+      attachPossibleException(exitCase) >> Sync[F].delay {
+        t.scopeManager().activate(s)
+        s.finish()
+      }
+    }
+
+  def entryPoint[F[_] : Sync](acquireTracer: F[ot.Tracer]): Resource[F, EntryPoint[F]] =
+    Resource.fromAutoCloseable(acquireTracer)
+      .map(t => new EntryPoint[F] {
+        override def root(name: String): Resource[F, Span[F]] =
+          makeSpan(t)(Sync[F].delay(t.buildSpan(name).start()))
+
+        override def continue(name: String, kernel: Kernel): Resource[F, Span[F]] = {
+          val acquireSpan: F[ot.Span] = Sync[F].delay {
+            val p = t.extract(
+              Format.Builtin.HTTP_HEADERS,
+              new TextMapAdapter(kernel.toHeaders.asJava)
+            )
+            t.buildSpan(name).asChildOf(p).start()
+          }
+
+          makeSpan(t)(acquireSpan)
+        }
+
+        override def continueOrElseRoot(name: String, kernel: Kernel): Resource[F, Span[F]] =
+          continue(name, kernel) flatMap {
+            case null => root(name) // hurr, means headers are incomplete or invalid
+            case a    => a.pure[Resource[F, *]]
+          } recoverWith {
+            case _: Exception => root(name)
+          }
+
+      })
+
+}

--- a/modules/opentracing/src/main/scala/OTTracer.scala
+++ b/modules/opentracing/src/main/scala/OTTracer.scala
@@ -6,14 +6,12 @@ package natchez
 package opentracing
 
 import cats.Applicative
-import cats.effect.{ExitCase, Resource, Sync}
-import cats.syntax.applicative._
-import cats.syntax.functor._
-import cats.syntax.flatMap._
-import cats.syntax.applicativeError._
+import cats.effect.{Bracket, ExitCase, Resource, Sync}
+import cats.implicits._
+import io.opentracing.SpanContext
 import io.opentracing.log.Fields
-import io.{opentracing => ot}
 import io.opentracing.propagation.{Format, TextMapAdapter}
+import io.{opentracing => ot}
 
 import scala.jdk.CollectionConverters._
 
@@ -22,7 +20,7 @@ object OTTracer {
   private [opentracing] def makeSpan[F[_] : Sync](t: ot.Tracer)(acquireSpan: F[ot.Span]): Resource[F, Span[F]] =
     Resource.makeCase(acquireSpan)(finishSpan(t)).map(OTSpan(t, _))
 
-  private def finishSpan[F[_] : Sync](t: ot.Tracer): (ot.Span, ExitCase[Throwable]) => F[Unit] =
+  private def finishSpan[F[_] : Bracket[*[_], Throwable] : Sync](t: ot.Tracer): (ot.Span, ExitCase[Throwable]) => F[Unit] =
     (s, exitCase) => {
       def attachPossibleException: ExitCase[Throwable] => F[Unit] = {
         case ExitCase.Error(ex) =>
@@ -33,28 +31,37 @@ object OTTracer {
         case _ => Applicative[F].unit
       }
 
-      attachPossibleException(exitCase) >> Sync[F].delay {
+      Bracket[F, Throwable].guarantee(attachPossibleException(exitCase))(Sync[F].delay {
         t.scopeManager().activate(s)
         s.finish()
-      }
+      })
     }
 
   def entryPoint[F[_] : Sync](acquireTracer: F[ot.Tracer]): Resource[F, EntryPoint[F]] =
     Resource.fromAutoCloseable(acquireTracer)
       .map(t => new EntryPoint[F] {
         override def root(name: String): Resource[F, Span[F]] =
-          makeSpan(t)(Sync[F].delay(t.buildSpan(name).start()))
+          makeSpan(t)(Sync[F].delay {
+            val newSpan = t.buildSpan(name).start()
+            t.scopeManager().activate(newSpan)
+            newSpan
+          })
 
         override def continue(name: String, kernel: Kernel): Resource[F, Span[F]] = {
-          val acquireSpan: F[ot.Span] = Sync[F].delay {
-            val p = t.extract(
+          val parentContext: F[SpanContext] = Sync[F].delay {
+            t.extract(
               Format.Builtin.HTTP_HEADERS,
               new TextMapAdapter(kernel.toHeaders.asJava)
             )
-            t.buildSpan(name).asChildOf(p).start()
           }
 
-          makeSpan(t)(acquireSpan)
+          makeSpan(t)(parentContext.flatMap { context =>
+            Sync[F].delay {
+              val newSpan: ot.Span = t.buildSpan(name).asChildOf(context).start()
+              t.scopeManager().activate(newSpan)
+              newSpan
+            }
+          })
         }
 
         override def continueOrElseRoot(name: String, kernel: Kernel): Resource[F, Span[F]] =


### PR DESCRIPTION
This should let us more easily add OpenTracing backends other than Jaeger. 

For example, I have it working with https://github.com/opentracing-contrib/java-xray-tracer locally, but that project is apparently having some problems with publishing artifacts. Once there's a reliable artifact available I'll PR the XRay backend too.