### PR TITLE
Add Mock open tracing implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ lazy val natchez = project
     crossScalaVersions := Nil,
     publish / skip     := true
   )
-  .dependsOn(core, jaeger, honeycomb, opencensus, datadog, lightstep, lightstepGrpc, lightstepHttp, log, noop, examples)
-  .aggregate(core, jaeger, honeycomb, opencensus, datadog, lightstep, lightstepGrpc, lightstepHttp, log, noop, examples)
+  .dependsOn(core, jaeger, honeycomb, opencensus, datadog, lightstep, lightstepGrpc, lightstepHttp, log, noop, mock, examples)
+  .aggregate(core, jaeger, honeycomb, opencensus, datadog, lightstep, lightstepGrpc, lightstepHttp, log, noop, mock, examples)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -182,6 +182,18 @@ lazy val noop = project
     description := "No-Op Open Tracing implementation",
     libraryDependencies ++= Seq()
     )
+
+lazy val mock = project
+  .in(file("modules/mock"))
+  .dependsOn(core)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-mock",
+    description := "Mock Open Tracing implementation",
+    libraryDependencies ++= Seq(
+      "io.opentracing" % "opentracing-mock" % "0.33.0"
+    ))
 
 
 lazy val examples = project

--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,8 @@ lazy val mock = project
     name        := "natchez-mock",
     description := "Mock Open Tracing implementation",
     libraryDependencies ++= Seq(
-      "io.opentracing" % "opentracing-mock" % "0.33.0"
+      "io.opentracing" % "opentracing-mock" % "0.33.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4"
     ))
 
 

--- a/modules/mock/src/main/scala/MockEntryPoint.scala
+++ b/modules/mock/src/main/scala/MockEntryPoint.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2019-2020 by Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package mock
+
+import scala.jdk.CollectionConverters._
+
+import cats.implicits._
+import cats.effect.{ Resource, Sync }
+import io.opentracing.mock.MockTracer
+import io.opentracing.propagation.{ Format, TextMapAdapter }
+
+final case class MockEntrypoint[F[_] : Sync]() extends EntryPoint[F] {
+
+  val mockTracer = new MockTracer()
+
+  override def root(name: String): Resource[F, Span[F]] = {
+    Resource
+      .make(Sync[F].delay(mockTracer.buildSpan(name).start()))(
+        span => Sync[F].delay(span.finish())
+        )
+      .map(MockSpan(mockTracer, _))
+  }
+
+  override def continue(
+    name: String,
+    kernel: Kernel
+  ): Resource[F, Span[F]] = {
+    Resource
+      .make(
+        Sync[F].delay {
+          val spanCtxt = mockTracer.extract(
+            Format.Builtin.HTTP_HEADERS,
+            new TextMapAdapter(kernel.toHeaders.asJava)
+            )
+          mockTracer.buildSpan(name).asChildOf(spanCtxt).start()
+        }
+        )(span => Sync[F].delay(span.finish()))
+      .map(MockSpan(mockTracer, _))
+  }
+
+  override def continueOrElseRoot(
+    name: String,
+    kernel: Kernel
+  ): Resource[F, Span[F]] = {
+    continue(name, kernel).flatMap {
+      case null =>
+        root(name)
+      case span => span.pure[Resource[F, ?]]
+    }
+  }
+}

--- a/modules/mock/src/main/scala/MockSpan.scala
+++ b/modules/mock/src/main/scala/MockSpan.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2019-2020 by Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package mock
+
+import scala.jdk.CollectionConverters._
+
+import cats.effect.{ Resource, Sync }
+import cats.implicits._
+import io.{ opentracing => ot }
+import io.opentracing.propagation.{ Format, TextMapAdapter }
+import natchez.TraceValue.{ BooleanValue, NumberValue, StringValue }
+
+final case class MockSpan[F[_] : Sync](
+  tracer: ot.mock.MockTracer,
+  span: ot.mock.MockSpan)
+  extends Span[F] {
+
+  def kernel: F[Kernel] =
+    Sync[F].delay {
+      val m = new java.util.HashMap[String, String]
+      tracer.inject(
+        span.context,
+        Format.Builtin.HTTP_HEADERS,
+        new TextMapAdapter(m)
+        )
+      Kernel(m.asScala.toMap)
+    }
+
+  def put(fields: (String, TraceValue)*): F[Unit] =
+    fields.toList.traverse_ {
+      case (k, StringValue(v)) => Sync[F].delay(span.setTag(k, v))
+      case (k, NumberValue(v)) => Sync[F].delay(span.setTag(k, v))
+      case (k, BooleanValue(v)) => Sync[F].delay(span.setTag(k, v))
+    }
+
+  def span(name: String): Resource[F, Span[F]] =
+    Resource
+      .make {
+        Sync[F].delay(tracer.buildSpan(name).asChildOf(span).start)
+      } { s =>
+        Sync[F].delay(s.finish())
+      }
+      .map(MockSpan(tracer, _))
+
+}


### PR DESCRIPTION
Add a module that uses `opentracing-mock` that can be used for testing. 

I chose to just expose the `MockTracer` as a public member of the entrypoint, so we can access all its methods. LMK if you would prefer to access it only through public methods of the `MockEntrypoint` class