### PR TITLE
3.0.0-M2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: olafurpg/setup-scala@v2
+        uses: olafurpg/setup-scala@v10
       - name: Cache SBT
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v2
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
       - name: Publish
         run: csbt ci-release
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,11 @@
-lazy val scala212Version = "2.12.12"
-lazy val scala213Version = "2.13.3"
-lazy val scala30Version = "3.0.0-M1"
+
+val scala212Version        = "2.12.12"
+val scala213Version        = "2.13.4"
+val scala30PreviousVersion = "3.0.0-M1"
+val scala30Version         = "3.0.0-M2"
+
+val catsVersion = "2.3.0"
+val catsEffectVersion = "2.3.0"
 
 // Global Settings
 lazy val commonSettings = Seq(
@@ -25,7 +30,7 @@ lazy val commonSettings = Seq(
 
   // Compilation
   scalaVersion       := scala213Version,
-  crossScalaVersions := Seq(scala212Version, scala213Version, scala30Version),
+  crossScalaVersions := Seq(scala212Version, scala213Version, scala30PreviousVersion, scala30Version),
   Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports"),
   Compile / doc     / scalacOptions --= Seq("-Xfatal-warnings"),
   Compile / doc     / scalacOptions ++= Seq(
@@ -34,7 +39,7 @@ lazy val commonSettings = Seq(
     "-doc-source-url", "https://github.com/tpolecat/natchez/blob/v" + version.value + "€{FILE_PATH}.scala"
   ),
   libraryDependencies ++= Seq(
-    compilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
+    compilerPlugin("org.typelevel" %% "kind-projector" % "0.11.1" cross CrossVersion.full),
   ).filterNot(_ => isDotty.value),
   scalacOptions ++= {
     if (isDotty.value) Seq(
@@ -93,8 +98,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     name        := "natchez-core",
     description := "Tagless, non-blocking OpenTracing implementation for Scala.",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core"   % "2.3.0-M2",
-      "org.typelevel" %%% "cats-effect" % "2.3.0-M1"
+      "org.typelevel" %%% "cats-core"   % catsVersion,
+      "org.typelevel" %%% "cats-effect" % catsEffectVersion,
     )
   )
 
@@ -104,7 +109,7 @@ lazy val coreJS = core.js
     scalaJSStage in Test := FastOptStage,
     jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
-    crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2."))
+    crossScalaVersions := crossScalaVersions.value.filterNot(_ == "3.0.0-M1"),
   )
 
 lazy val jaeger = project
@@ -225,7 +230,7 @@ lazy val logJS = log.js
     scalaJSStage in Test := FastOptStage,
     jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
-    crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2."))
+    crossScalaVersions := crossScalaVersions.value.filterNot(_ == "3.0.0-M1"),
   )
 
 lazy val newrelic = project


### PR DESCRIPTION
This adds support for Scala 3.0.0-M2, which also makes the core module available for scala-js. Still waiting on circe for the log and newrelic modules.