### PR TITLE
DataDog - Log Errors

### DIFF
--- a/modules/datadog/src/main/scala/DDSpan.scala
+++ b/modules/datadog/src/main/scala/DDSpan.scala
@@ -6,12 +6,10 @@ package natchez
 package datadog
 
 import io.{opentracing => ot}
-import cats.effect.Sync
-import cats.effect.Resource
+import cats.effect.{ExitCase, Resource, Sync}
 import cats.syntax.all._
 import io.opentracing.propagation.{Format, TextMapAdapter}
 import natchez.TraceValue.{BooleanValue, NumberValue, StringValue}
-
 import scala.jdk.CollectionConverters._
 import java.net.URI
 
@@ -38,10 +36,11 @@ private[datadog] final case class DDSpan[F[_]: Sync](
     }
 
   def span(name: String): Resource[F,Span[F]] =
-    Resource.make(
-      Sync[F].delay(tracer.buildSpan(name).asChildOf(span).start))(
-      s => Sync[F].delay(s.finish)
-    ).map(DDSpan(tracer, _))
+    Resource.makeCase(
+      Sync[F].delay(tracer.buildSpan(name).asChildOf(span).start)) {
+      case (span, ExitCase.Error(e)) => Sync[F].delay(span.log(e.toString).finish())
+      case (span, _) => Sync[F].delay(span.finish())
+    }.map(DDSpan(tracer, _))
 
   // TODO
   def traceId: F[Option[String]] = none.pure[F]


### PR DESCRIPTION
This PR adds some error-handling to the Span creation, ensuring that errors are propagated to the tracer.