### PR TITLE
Allow spans to be propagated outside monadic scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-val scala212Version = "2.12.12"
-val scala213Version = "2.13.5"
+val scala212Version        = "2.12.12"
+val scala213Version        = "2.13.5"
 val scala30PreviousVersion = "3.0.0-RC2"
-val scala30Version = "3.0.0-RC3"
+val scala30Version         = "3.0.0-RC3"
 
 val collectionCompatVersion = "2.4.3"
 
@@ -11,18 +11,18 @@ val catsEffectVersion = "2.5.0"
 // We do `evictionCheck` in CI and don't sweat the Java deps for now.
 inThisBuild(Seq(
   evictionRules ++= Seq(
-    "io.netty" % "*" % "always",
-    "io.grpc" % "*" % "always",
-    "com.github.jnr" % "*" % "always",
-    "com.google.guava" % "*" % "always",
-    "io.opentracing" % "*" % "always",
+    "io.netty"               % "*" % "always",
+    "io.grpc"                % "*" % "always",
+    "com.github.jnr"         % "*" % "always",
+    "com.google.guava"       % "*" % "always",
+    "io.opentracing"         % "*" % "always",
     "io.opentracing.contrib" % "*" % "always",
-    "com.squareup.okhttp3" % "*" % "always",
-    "com.squareup.okio" % "*" % "always",
+    "com.squareup.okhttp3"   % "*" % "always",
+    "com.squareup.okio"      % "*" % "always",
     "com.newrelic.telemetry" % "*" % "always",
-    "org.typelevel" % "*" % "semver-spec",
-    "org.scala-js" % "*" % "semver-spec",
-    "org.jctools" % "*" % "always",
+    "org.typelevel"          % "*" % "semver-spec",
+    "org.scala-js"           % "*" % "semver-spec",
+    "org.jctools"            % "*" % "always",
   )
 ))
 
@@ -31,35 +31,35 @@ lazy val commonSettings = Seq(
 
   // Publishing
   organization := "org.tpolecat",
-  licenses ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
-  homepage := Some(url("https://github.com/tpolecat/natchez")),
-  developers := List(
+  licenses    ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
+  homepage     := Some(url("https://github.com/tpolecat/natchez")),
+  developers   := List(
     Developer("tpolecat", "Rob Norris", "rob_norris@mac.com", url("http://www.tpolecat.org"))
   ),
 
   // Headers
   headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
-  headerLicense := Some(HeaderLicense.Custom(
+  headerLicense  := Some(HeaderLicense.Custom(
     """|Copyright (c) 2019-2020 by Rob Norris and Contributors
        |This software is licensed under the MIT License (MIT).
        |For more information see LICENSE or https://opensource.org/licenses/MIT
        |""".stripMargin
-  )
+    )
   ),
 
   // Testing
   libraryDependencies ++= Seq(
-    "org.scalameta" %%% "munit" % "0.7.25" % Test,
-    "org.typelevel" %%% "munit-cats-effect-2" % "1.0.2" % Test,
+    "org.scalameta" %%% "munit"               % "0.7.25" % Test,
+    "org.typelevel" %%% "munit-cats-effect-2" % "1.0.2"  % Test,
   ),
   testFrameworks += new TestFramework("munit.Framework"),
 
   // Compilation
-  scalaVersion := scala213Version,
+  scalaVersion       := scala213Version,
   crossScalaVersions := Seq(scala212Version, scala213Version, scala30PreviousVersion, scala30Version),
   Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports"),
-  Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
-  Compile / doc / scalacOptions ++= Seq(
+  Compile / doc     / scalacOptions --= Seq("-Xfatal-warnings"),
+  Compile / doc     / scalacOptions ++= Seq(
     "-groups",
     "-sourcepath", (LocalRootProject / baseDirectory).value.getAbsolutePath,
     "-doc-source-url", "https://github.com/tpolecat/natchez/blob/v" + version.value + "€{FILE_PATH}.scala"
@@ -72,9 +72,9 @@ lazy val commonSettings = Seq(
   Compile / unmanagedSourceDirectories ++= {
     val sourceDir = (Compile / sourceDirectory).value
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, _)) => Seq(sourceDir / "scala-3")
-      case Some((2, _)) => Seq(sourceDir / "scala-2")
-      case _ => Seq()
+      case Some((3, _))  => Seq(sourceDir / "scala-3")
+      case Some((2, _))  => Seq(sourceDir / "scala-2")
+      case _             => Seq()
     }
   },
 
@@ -82,9 +82,9 @@ lazy val commonSettings = Seq(
   Test / unmanagedSourceDirectories ++= {
     val sourceDir = (Test / sourceDirectory).value
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, _)) => Seq(sourceDir / "scala-3")
-      case Some((2, _)) => Seq(sourceDir / "scala-2")
-      case _ => Seq()
+      case Some((3, _))  => Seq(sourceDir / "scala-3")
+      case Some((2, _))  => Seq(sourceDir / "scala-2")
+      case _             => Seq()
     }
   },
 
@@ -119,7 +119,7 @@ lazy val natchez = project
   .settings(commonSettings)
   .settings(
     crossScalaVersions := Nil,
-    publish / skip := true
+    publish / skip     := true
   )
   .dependsOn(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, noop, mock, newrelic, logOdin, examples)
   .aggregate(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, noop, mock, newrelic, logOdin, examples)
@@ -130,10 +130,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(crossProjectSettings)
   .settings(
-    name := "natchez-core",
+    name        := "natchez-core",
     description := "Tagless, non-blocking OpenTracing implementation for Scala.",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core" % catsVersion,
+      "org.typelevel" %%% "cats-core"   % catsVersion,
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
     )
   )
@@ -152,11 +152,11 @@ lazy val jaeger = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-jaeger",
+    name        := "natchez-jaeger",
     description := "Jaeger support for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "io.jaegertracing" % "jaeger-client" % "1.6.0",
+      "io.jaegertracing"        % "jaeger-client"           % "1.6.0",
     )
   )
 
@@ -166,11 +166,11 @@ lazy val honeycomb = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-honeycomb",
+    name        := "natchez-honeycomb",
     description := "Honeycomb support for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "io.honeycomb.libhoney" % "libhoney-java" % "1.3.1"
+      "io.honeycomb.libhoney"   % "libhoney-java"           % "1.3.1"
     )
   )
 
@@ -193,11 +193,11 @@ lazy val lightstep = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-lightstep",
-    description := "Lightstep support for Natchez.",
+    name           := "natchez-lightstep",
+    description    := "Lightstep support for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "com.lightstep.tracer" % "lightstep-tracer-jre" % "0.30.5"
+      "com.lightstep.tracer"    % "lightstep-tracer-jre"    % "0.30.5"
     )
   )
 
@@ -207,12 +207,12 @@ lazy val lightstepGrpc = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-lightstep-grpc",
+    name        := "natchez-lightstep-grpc",
     description := "Lightstep gRPC bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "com.lightstep.tracer" % "tracer-grpc" % "0.30.3",
-      "io.grpc" % "grpc-netty" % "1.37.1",
-      "io.netty" % "netty-tcnative-boringssl-static" % "2.0.39.Final"
+      "com.lightstep.tracer" % "tracer-grpc"                     % "0.30.3",
+      "io.grpc"              % "grpc-netty"                      % "1.37.1",
+      "io.netty"             % "netty-tcnative-boringssl-static" % "2.0.39.Final"
     )
   )
 
@@ -235,7 +235,7 @@ lazy val opentracing = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-opentracing",
+    name        := "natchez-opentracing",
     description := "Base OpenTracing Utilities for Natchez",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
@@ -251,11 +251,11 @@ lazy val datadog = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-datadog",
+    name        := "natchez-datadog",
     description := "Datadog bindings for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "com.datadoghq" % "dd-trace-ot" % "0.78.3",
+      "com.datadoghq" % "dd-trace-ot"  % "0.78.3",
       "com.datadoghq" % "dd-trace-api" % "0.78.3"
     )
   )
@@ -266,15 +266,15 @@ lazy val log = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(crossProjectSettings)
   .settings(
-    name := "natchez-log",
+    name        := "natchez-log",
     description := "Logging bindings for Natchez, using log4cats.",
     libraryDependencies ++= Seq(
-      "io.circe" %%% "circe-core" % {
-        if (scalaVersion.value == scala30PreviousVersion) "0.14.0-M5"
-        else if (scalaVersion.value == scala30Version) "0.14.0-M6"
-        else "0.13.0"
+      "io.circe"          %%% "circe-core"    % {
+             if (scalaVersion.value == scala30PreviousVersion) "0.14.0-M5"
+        else if (scalaVersion.value == scala30Version)         "0.14.0-M6"
+        else                                                   "0.13.0"
       },
-      "org.typelevel" %%% "log4cats-core" % "1.3.0",
+      "org.typelevel"     %%% "log4cats-core"   % "1.3.0",
       "io.github.cquiroz" %%% "scala-java-time" % "2.2.2" % Test,
     )
   )
@@ -293,14 +293,14 @@ lazy val newrelic = project
   .settings(commonSettings)
   .settings(
     publish / skip := scalaVersion.value.startsWith("3."),
-    name := "newrelic",
+    name        := "newrelic",
     description := "Newrelic bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core" % "0.13.0",
+      "io.circe"               %% "circe-core"              % "0.13.0",
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "com.newrelic.telemetry" % "telemetry" % "0.10.0",
-      "com.newrelic.telemetry" % "telemetry-core" % "0.12.0",
-      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.12.0"
+      "com.newrelic.telemetry" % "telemetry"                % "0.10.0",
+      "com.newrelic.telemetry" % "telemetry-core"           % "0.12.0",
+      "com.newrelic.telemetry" % "telemetry-http-okhttp"    % "0.12.0"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
 
@@ -309,10 +309,10 @@ lazy val mtl = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-mtl",
+    name        := "natchez-mtl",
     description := "cats-mtl bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-mtl" % "1.2.0",
+      "org.typelevel"          %%% "cats-mtl"    % "1.2.0",
     )
   )
 
@@ -330,10 +330,10 @@ lazy val noop = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-noop",
+    name        := "natchez-noop",
     description := "No-Op Open Tracing implementation",
     libraryDependencies ++= Seq()
-  )
+    )
 
 lazy val mock = project
   .in(file("modules/mock"))
@@ -341,7 +341,7 @@ lazy val mock = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-mock",
+    name        := "natchez-mock",
     description := "Mock Open Tracing implementation",
     libraryDependencies ++= Seq(
       "io.opentracing" % "opentracing-mock" % "0.33.0",
@@ -355,16 +355,16 @@ lazy val examples = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    publish / skip := true,
-    name := "natchez-examples",
-    description := "Example programs for Natchez.",
-    scalacOptions -= "-Xfatal-warnings",
+    publish / skip       := true,
+    name                 := "natchez-examples",
+    description          := "Example programs for Natchez.",
+    scalacOptions        -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "io.chrisdavenport" %% "log4cats-slf4j" % "1.1.1",
-      "org.slf4j" % "slf4j-simple" % "1.7.30",
-      "eu.timepit" %% "refined" % "0.9.25",
-      "is.cir" %% "ciris" % "1.2.1",
-      "co.fs2" %% "fs2-core" % "2.5.6"
+      "org.slf4j"         % "slf4j-simple"    % "1.7.30",
+      "eu.timepit"        %% "refined"        % "0.9.25",
+      "is.cir"            %% "ciris"          % "1.2.1",
+      "co.fs2"            %% "fs2-core"       % "2.5.6"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
 
@@ -375,12 +375,12 @@ lazy val logOdin = project
   .settings(commonSettings)
   .settings(
     publish / skip := scalaVersion.value.startsWith("3."),
-    name := "natchez-log-odin",
+    name        := "natchez-log-odin",
     description := "Logging bindings for Natchez, using Odin.",
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core" % "0.13.0",
-      "com.github.valskalla" %% "odin-core" % "0.9.1",
-      "com.github.valskalla" %% "odin-json" % "0.9.1"
+      "io.circe"              %% "circe-core" % "0.13.0",
+      "com.github.valskalla"  %% "odin-core"  % "0.9.1",
+      "com.github.valskalla"  %% "odin-json"  % "0.9.1"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
 
@@ -394,18 +394,18 @@ lazy val docs = project
   .enablePlugins(MdocPlugin)
   .settings(commonSettings)
   .settings(
-    scalacOptions := Nil,
-    git.remoteRepo := "git@github.com:tpolecat/natchez.git",
-    ghpagesNoJekyll := true,
-    publish / skip := true,
-    paradoxTheme := Some(builtinParadoxTheme("generic")),
-    version := version.value.takeWhile(_ != '+'), // strip off the +3-f22dca22+20191110-1520-SNAPSHOT business
+    scalacOptions      := Nil,
+    git.remoteRepo     := "git@github.com:tpolecat/natchez.git",
+    ghpagesNoJekyll    := true,
+    publish / skip     := true,
+    paradoxTheme       := Some(builtinParadoxTheme("generic")),
+    version            := version.value.takeWhile(_ != '+'), // strip off the +3-f22dca22+20191110-1520-SNAPSHOT business
     paradoxProperties ++= Map(
-      "scala-versions" -> (coreJVM / crossScalaVersions).value.map(CrossVersion.partialVersion).flatten.distinct.map { case (a, b) => s"$a.$b" }.mkString("/"),
-      "org" -> organization.value,
-      "scala.binary.version" -> s"2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
-      "core-dep" -> s"${(coreJVM / name).value}_2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
-      "version" -> version.value,
+      "scala-versions"            -> (coreJVM / crossScalaVersions).value.map(CrossVersion.partialVersion).flatten.distinct.map { case (a, b) => s"$a.$b"} .mkString("/"),
+      "org"                       -> organization.value,
+      "scala.binary.version"      -> s"2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
+      "core-dep"                  -> s"${(coreJVM / name).value}_2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
+      "version"                   -> version.value,
       "scaladoc.natchez.base_url" -> s"https://static.javadoc.io/org.tpolecat/natchez-core_2.13/${version.value}",
     ),
     mdocIn := (baseDirectory.value) / "src" / "main" / "paradox",

--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,7 @@ lazy val opencensus = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-opencensus",
+    name        := "natchez-opencensus",
     description := "Opencensus support for Natchez.",
     libraryDependencies ++= Seq(
       "io.opencensus" % "opencensus-exporter-trace-ocagent" % "0.28.3"
@@ -222,7 +222,7 @@ lazy val lightstepHttp = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name := "natchez-lightstep-http",
+    name        := "natchez-lightstep-http",
     description := "Lightstep HTTP bindings for Natchez.",
     libraryDependencies ++= Seq(
       "com.lightstep.tracer" % "tracer-okhttp" % "0.30.3"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-val scala212Version        = "2.12.12"
-val scala213Version        = "2.13.5"
+val scala212Version = "2.12.12"
+val scala213Version = "2.13.5"
 val scala30PreviousVersion = "3.0.0-RC2"
-val scala30Version         = "3.0.0-RC3"
+val scala30Version = "3.0.0-RC3"
 
 val collectionCompatVersion = "2.4.3"
 
@@ -11,18 +11,18 @@ val catsEffectVersion = "2.5.0"
 // We do `evictionCheck` in CI and don't sweat the Java deps for now.
 inThisBuild(Seq(
   evictionRules ++= Seq(
-    "io.netty"               % "*" % "always",
-    "io.grpc"                % "*" % "always",
-    "com.github.jnr"         % "*" % "always",
-    "com.google.guava"       % "*" % "always",
-    "io.opentracing"         % "*" % "always",
+    "io.netty" % "*" % "always",
+    "io.grpc" % "*" % "always",
+    "com.github.jnr" % "*" % "always",
+    "com.google.guava" % "*" % "always",
+    "io.opentracing" % "*" % "always",
     "io.opentracing.contrib" % "*" % "always",
-    "com.squareup.okhttp3"   % "*" % "always",
-    "com.squareup.okio"      % "*" % "always",
+    "com.squareup.okhttp3" % "*" % "always",
+    "com.squareup.okio" % "*" % "always",
     "com.newrelic.telemetry" % "*" % "always",
-    "org.typelevel"          % "*" % "semver-spec",
-    "org.scala-js"           % "*" % "semver-spec",
-    "org.jctools"            % "*" % "always",
+    "org.typelevel" % "*" % "semver-spec",
+    "org.scala-js" % "*" % "semver-spec",
+    "org.jctools" % "*" % "always",
   )
 ))
 
@@ -31,35 +31,35 @@ lazy val commonSettings = Seq(
 
   // Publishing
   organization := "org.tpolecat",
-  licenses    ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
-  homepage     := Some(url("https://github.com/tpolecat/natchez")),
-  developers   := List(
+  licenses ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
+  homepage := Some(url("https://github.com/tpolecat/natchez")),
+  developers := List(
     Developer("tpolecat", "Rob Norris", "rob_norris@mac.com", url("http://www.tpolecat.org"))
   ),
 
   // Headers
   headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
-  headerLicense  := Some(HeaderLicense.Custom(
+  headerLicense := Some(HeaderLicense.Custom(
     """|Copyright (c) 2019-2020 by Rob Norris and Contributors
        |This software is licensed under the MIT License (MIT).
        |For more information see LICENSE or https://opensource.org/licenses/MIT
        |""".stripMargin
-    )
+  )
   ),
 
   // Testing
   libraryDependencies ++= Seq(
-    "org.scalameta" %%% "munit"               % "0.7.25" % Test,
-    "org.typelevel" %%% "munit-cats-effect-2" % "1.0.2"  % Test,
+    "org.scalameta" %%% "munit" % "0.7.25" % Test,
+    "org.typelevel" %%% "munit-cats-effect-2" % "1.0.2" % Test,
   ),
   testFrameworks += new TestFramework("munit.Framework"),
 
   // Compilation
-  scalaVersion       := scala213Version,
+  scalaVersion := scala213Version,
   crossScalaVersions := Seq(scala212Version, scala213Version, scala30PreviousVersion, scala30Version),
   Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports"),
-  Compile / doc     / scalacOptions --= Seq("-Xfatal-warnings"),
-  Compile / doc     / scalacOptions ++= Seq(
+  Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
+  Compile / doc / scalacOptions ++= Seq(
     "-groups",
     "-sourcepath", (LocalRootProject / baseDirectory).value.getAbsolutePath,
     "-doc-source-url", "https://github.com/tpolecat/natchez/blob/v" + version.value + "€{FILE_PATH}.scala"
@@ -72,9 +72,9 @@ lazy val commonSettings = Seq(
   Compile / unmanagedSourceDirectories ++= {
     val sourceDir = (Compile / sourceDirectory).value
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, _))  => Seq(sourceDir / "scala-3")
-      case Some((2, _))  => Seq(sourceDir / "scala-2")
-      case _             => Seq()
+      case Some((3, _)) => Seq(sourceDir / "scala-3")
+      case Some((2, _)) => Seq(sourceDir / "scala-2")
+      case _ => Seq()
     }
   },
 
@@ -82,9 +82,9 @@ lazy val commonSettings = Seq(
   Test / unmanagedSourceDirectories ++= {
     val sourceDir = (Test / sourceDirectory).value
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, _))  => Seq(sourceDir / "scala-3")
-      case Some((2, _))  => Seq(sourceDir / "scala-2")
-      case _             => Seq()
+      case Some((3, _)) => Seq(sourceDir / "scala-3")
+      case Some((2, _)) => Seq(sourceDir / "scala-2")
+      case _ => Seq()
     }
   },
 
@@ -119,7 +119,7 @@ lazy val natchez = project
   .settings(commonSettings)
   .settings(
     crossScalaVersions := Nil,
-    publish / skip     := true
+    publish / skip := true
   )
   .dependsOn(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, noop, mock, newrelic, logOdin, examples)
   .aggregate(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, noop, mock, newrelic, logOdin, examples)
@@ -130,10 +130,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(crossProjectSettings)
   .settings(
-    name        := "natchez-core",
+    name := "natchez-core",
     description := "Tagless, non-blocking OpenTracing implementation for Scala.",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core"   % catsVersion,
+      "org.typelevel" %%% "cats-core" % catsVersion,
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
     )
   )
@@ -152,11 +152,11 @@ lazy val jaeger = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-jaeger",
+    name := "natchez-jaeger",
     description := "Jaeger support for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "io.jaegertracing"        % "jaeger-client"           % "1.6.0",
+      "io.jaegertracing" % "jaeger-client" % "1.6.0",
     )
   )
 
@@ -166,11 +166,11 @@ lazy val honeycomb = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-honeycomb",
+    name := "natchez-honeycomb",
     description := "Honeycomb support for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "io.honeycomb.libhoney"   % "libhoney-java"           % "1.3.1"
+      "io.honeycomb.libhoney" % "libhoney-java" % "1.3.1"
     )
   )
 
@@ -180,7 +180,7 @@ lazy val opencensus = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-opencensus",
+    name := "natchez-opencensus",
     description := "Opencensus support for Natchez.",
     libraryDependencies ++= Seq(
       "io.opencensus" % "opencensus-exporter-trace-ocagent" % "0.28.3"
@@ -193,11 +193,11 @@ lazy val lightstep = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name           := "natchez-lightstep",
-    description    := "Lightstep support for Natchez.",
+    name := "natchez-lightstep",
+    description := "Lightstep support for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "com.lightstep.tracer"    % "lightstep-tracer-jre"    % "0.30.5"
+      "com.lightstep.tracer" % "lightstep-tracer-jre" % "0.30.5"
     )
   )
 
@@ -207,12 +207,12 @@ lazy val lightstepGrpc = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-lightstep-grpc",
+    name := "natchez-lightstep-grpc",
     description := "Lightstep gRPC bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "com.lightstep.tracer" % "tracer-grpc"                     % "0.30.3",
-      "io.grpc"              % "grpc-netty"                      % "1.37.1",
-      "io.netty"             % "netty-tcnative-boringssl-static" % "2.0.39.Final"
+      "com.lightstep.tracer" % "tracer-grpc" % "0.30.3",
+      "io.grpc" % "grpc-netty" % "1.37.1",
+      "io.netty" % "netty-tcnative-boringssl-static" % "2.0.39.Final"
     )
   )
 
@@ -222,7 +222,7 @@ lazy val lightstepHttp = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-lightstep-http",
+    name := "natchez-lightstep-http",
     description := "Lightstep HTTP bindings for Natchez.",
     libraryDependencies ++= Seq(
       "com.lightstep.tracer" % "tracer-okhttp" % "0.30.3"
@@ -235,7 +235,7 @@ lazy val opentracing = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-opentracing",
+    name := "natchez-opentracing",
     description := "Base OpenTracing Utilities for Natchez",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
@@ -251,11 +251,11 @@ lazy val datadog = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-datadog",
+    name := "natchez-datadog",
     description := "Datadog bindings for Natchez.",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "com.datadoghq" % "dd-trace-ot"  % "0.78.3",
+      "com.datadoghq" % "dd-trace-ot" % "0.78.3",
       "com.datadoghq" % "dd-trace-api" % "0.78.3"
     )
   )
@@ -266,15 +266,15 @@ lazy val log = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(crossProjectSettings)
   .settings(
-    name        := "natchez-log",
+    name := "natchez-log",
     description := "Logging bindings for Natchez, using log4cats.",
     libraryDependencies ++= Seq(
-      "io.circe"          %%% "circe-core"    % {
-             if (scalaVersion.value == scala30PreviousVersion) "0.14.0-M5"
-        else if (scalaVersion.value == scala30Version)         "0.14.0-M6"
-        else                                                   "0.13.0"
+      "io.circe" %%% "circe-core" % {
+        if (scalaVersion.value == scala30PreviousVersion) "0.14.0-M5"
+        else if (scalaVersion.value == scala30Version) "0.14.0-M6"
+        else "0.13.0"
       },
-      "org.typelevel"     %%% "log4cats-core"   % "1.3.0",
+      "org.typelevel" %%% "log4cats-core" % "1.3.0",
       "io.github.cquiroz" %%% "scala-java-time" % "2.2.2" % Test,
     )
   )
@@ -293,14 +293,14 @@ lazy val newrelic = project
   .settings(commonSettings)
   .settings(
     publish / skip := scalaVersion.value.startsWith("3."),
-    name        := "newrelic",
+    name := "newrelic",
     description := "Newrelic bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "io.circe"               %% "circe-core"              % "0.13.0",
+      "io.circe" %% "circe-core" % "0.13.0",
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "com.newrelic.telemetry" % "telemetry"                % "0.10.0",
-      "com.newrelic.telemetry" % "telemetry-core"           % "0.12.0",
-      "com.newrelic.telemetry" % "telemetry-http-okhttp"    % "0.12.0"
+      "com.newrelic.telemetry" % "telemetry" % "0.10.0",
+      "com.newrelic.telemetry" % "telemetry-core" % "0.12.0",
+      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.12.0"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
 
@@ -309,10 +309,10 @@ lazy val mtl = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-mtl",
+    name := "natchez-mtl",
     description := "cats-mtl bindings for Natchez.",
     libraryDependencies ++= Seq(
-      "org.typelevel"          %%% "cats-mtl"    % "1.2.0",
+      "org.typelevel" %%% "cats-mtl" % "1.2.0",
     )
   )
 
@@ -330,10 +330,10 @@ lazy val noop = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-noop",
+    name := "natchez-noop",
     description := "No-Op Open Tracing implementation",
     libraryDependencies ++= Seq()
-    )
+  )
 
 lazy val mock = project
   .in(file("modules/mock"))
@@ -341,7 +341,7 @@ lazy val mock = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    name        := "natchez-mock",
+    name := "natchez-mock",
     description := "Mock Open Tracing implementation",
     libraryDependencies ++= Seq(
       "io.opentracing" % "opentracing-mock" % "0.33.0",
@@ -355,15 +355,16 @@ lazy val examples = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
-    publish / skip       := true,
-    name                 := "natchez-examples",
-    description          := "Example programs for Natchez.",
-    scalacOptions        -= "-Xfatal-warnings",
+    publish / skip := true,
+    name := "natchez-examples",
+    description := "Example programs for Natchez.",
+    scalacOptions -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "io.chrisdavenport" %% "log4cats-slf4j" % "1.1.1",
-      "org.slf4j"         % "slf4j-simple"    % "1.7.30",
-      "eu.timepit"        %% "refined"        % "0.9.25",
-      "is.cir"            %% "ciris"          % "1.2.1"
+      "org.slf4j" % "slf4j-simple" % "1.7.30",
+      "eu.timepit" %% "refined" % "0.9.25",
+      "is.cir" %% "ciris" % "1.2.1",
+      "co.fs2" %% "fs2-core" % "2.5.6"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
 
@@ -374,12 +375,12 @@ lazy val logOdin = project
   .settings(commonSettings)
   .settings(
     publish / skip := scalaVersion.value.startsWith("3."),
-    name        := "natchez-log-odin",
+    name := "natchez-log-odin",
     description := "Logging bindings for Natchez, using Odin.",
     libraryDependencies ++= Seq(
-      "io.circe"              %% "circe-core" % "0.13.0",
-      "com.github.valskalla"  %% "odin-core"  % "0.9.1",
-      "com.github.valskalla"  %% "odin-json"  % "0.9.1"
+      "io.circe" %% "circe-core" % "0.13.0",
+      "com.github.valskalla" %% "odin-core" % "0.9.1",
+      "com.github.valskalla" %% "odin-json" % "0.9.1"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
 
@@ -393,18 +394,18 @@ lazy val docs = project
   .enablePlugins(MdocPlugin)
   .settings(commonSettings)
   .settings(
-    scalacOptions      := Nil,
-    git.remoteRepo     := "git@github.com:tpolecat/natchez.git",
-    ghpagesNoJekyll    := true,
-    publish / skip     := true,
-    paradoxTheme       := Some(builtinParadoxTheme("generic")),
-    version            := version.value.takeWhile(_ != '+'), // strip off the +3-f22dca22+20191110-1520-SNAPSHOT business
+    scalacOptions := Nil,
+    git.remoteRepo := "git@github.com:tpolecat/natchez.git",
+    ghpagesNoJekyll := true,
+    publish / skip := true,
+    paradoxTheme := Some(builtinParadoxTheme("generic")),
+    version := version.value.takeWhile(_ != '+'), // strip off the +3-f22dca22+20191110-1520-SNAPSHOT business
     paradoxProperties ++= Map(
-      "scala-versions"            -> (coreJVM / crossScalaVersions).value.map(CrossVersion.partialVersion).flatten.distinct.map { case (a, b) => s"$a.$b"} .mkString("/"),
-      "org"                       -> organization.value,
-      "scala.binary.version"      -> s"2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
-      "core-dep"                  -> s"${(coreJVM / name).value}_2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
-      "version"                   -> version.value,
+      "scala-versions" -> (coreJVM / crossScalaVersions).value.map(CrossVersion.partialVersion).flatten.distinct.map { case (a, b) => s"$a.$b" }.mkString("/"),
+      "org" -> organization.value,
+      "scala.binary.version" -> s"2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
+      "core-dep" -> s"${(coreJVM / name).value}_2.${CrossVersion.partialVersion(scalaVersion.value).get._2}",
+      "version" -> version.value,
       "scaladoc.natchez.base_url" -> s"https://static.javadoc.io/org.tpolecat/natchez-core_2.13/${version.value}",
     ),
     mdocIn := (baseDirectory.value) / "src" / "main" / "paradox",

--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -61,7 +61,7 @@ object Trace {
         val kernel: F[Kernel] = Kernel(Map.empty).pure[F]
         def put(fields: (String, TraceValue)*): F[Unit] = void
         def span[A](name: String)(k: F[A]): F[A] = k
-        def portal: F[Portal[F]] = Applicative[F].pure(new Portal[F] {
+        def portal: F[Portal[F]] = Applicative[F].pure(new (F ~> F) {
           def apply[A](fa: F[A]): F[A] = fa
         })
         def traceId: F[Option[String]] = none.pure[F]
@@ -256,5 +256,3 @@ object Trace {
       }
     }
 }
-
-trait Portal[F[_]] extends (F ~> F)

--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -111,7 +111,7 @@ object Trace {
         def traceUri: Kleisli[F,E,Option[URI]] =
           Kleisli(e => f(e).traceUri)
 
-        def portal: ReaderT[F, E, Portal[ReaderT[F, E, *]]] = Kleisli(e =>
+        def portal: Kleisli[F, E, Portal[Kleisli[F, E, *]]] = Kleisli(e =>
           Applicative[F].pure(new Portal[Kleisli[F, E, *]] {
             override def apply[A](fa: Kleisli[F, E, A]): Kleisli[F, E, A] = Kleisli.liftF(fa.run(e))
           })
@@ -149,8 +149,8 @@ object Trace {
         Kleisli.liftF(trace.traceUri)
 
       def portal: Kleisli[F, E, Portal[Kleisli[F, E, *]]] = Kleisli.liftF(trace.portal).map { portal =>
-        new Portal[ReaderT[F, E, *]] {
-          def apply[A](fa: ReaderT[F, E, A]): ReaderT[F, E, A] = fa.mapK(portal)
+        new Portal[Kleisli[F, E, *]] {
+          def apply[A](fa: Kleisli[F, E, A]): Kleisli[F, E, A] = fa.mapK(portal)
         }
       }
     }

--- a/modules/core/shared/src/main/scala/natchez.scala
+++ b/modules/core/shared/src/main/scala/natchez.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2019-2020 by Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+import cats.~>
+
+package object natchez {
+  type Portal[F[_]] = F ~> F
+}

--- a/modules/core/shared/src/test/scala/ImplicitResolutionTest.scala
+++ b/modules/core/shared/src/test/scala/ImplicitResolutionTest.scala
@@ -5,7 +5,9 @@
 package natchez
 
 import cats.data._
+import cats.Functor
 import cats.effect.Bracket
+import natchez.Trace.Implicits.noop
 
 object ImplicitResolutionTest {
 
@@ -13,7 +15,7 @@ object ImplicitResolutionTest {
   def kleisliTrace[F[_]](implicit ev: Bracket[F, Throwable]) =
     Trace[Kleisli[F, Span[F], *]]
 
-  def kleisliLiftedTrace[F[_]: Trace] =
+  def kleisliLiftedTrace[F[_]: Trace: Functor] =
     Trace[Kleisli[F, Int, *]]
 
   def kleisliKleisliTrace[F[_]](implicit ev: Bracket[F, Throwable]) =

--- a/modules/examples/src/main/scala-2/Example.scala
+++ b/modules/examples/src/main/scala-2/Example.scala
@@ -15,7 +15,7 @@ import java.net.URI
 
 object Main extends IOApp {
 
-  def runF[F[_]: Sync: Trace: Parallel: Timer]: F[Unit] =
+  def runF[F[_]: Concurrent: Trace: Parallel: Timer]: F[Unit] =
     Trace[F].span("Sort some stuff!") {
       for {
         as <- Sync[F].delay(List.fill(10)(Random.nextInt(1000)))

--- a/modules/examples/src/main/scala-2/GlobalTracerExample.scala
+++ b/modules/examples/src/main/scala-2/GlobalTracerExample.scala
@@ -16,7 +16,7 @@ import java.net.URI
 
 object GlobalTracerMain extends IOApp {
 
-  def runF[F[_]: Sync: Trace: Parallel: Timer]: F[Unit] =
+  def runF[F[_]: Concurrent: Trace: Parallel: Timer]: F[Unit] =
     Trace[F].span("Sort some stuff!") {
       for {
         as <- Sync[F].delay(List.fill(10)(Random.nextInt(1000)))

--- a/modules/examples/src/main/scala-2/Sort.scala
+++ b/modules/examples/src/main/scala-2/Sort.scala
@@ -8,11 +8,10 @@ import cats._
 import cats.effect.concurrent.Deferred
 import cats.effect.{Concurrent, Timer}
 import cats.syntax.all._
-import natchez.{Kernel, Portal, Trace, TraceValue}
+import natchez.{Portal, Trace}
 import fs2._
 import fs2.concurrent.Queue
 
-import java.net.URI
 import scala.concurrent.duration._
 
 object Sort {

--- a/modules/examples/src/main/scala-2/Sort.scala
+++ b/modules/examples/src/main/scala-2/Sort.scala
@@ -5,24 +5,54 @@
 package example
 
 import cats._
-import cats.effect.Timer
+import cats.effect.concurrent.Deferred
+import cats.effect.{Concurrent, Timer}
 import cats.syntax.all._
-import natchez.Trace
+import natchez.{Portal, Trace}
+import fs2._
+import fs2.concurrent.Queue
+
 import scala.concurrent.duration._
 
 object Sort {
 
   // Intentionally slow parallel quicksort, to demonstrate branching. If we run too quickly it seems
   // to break Jaeger with "skipping clock skew adjustment" so let's pause a bit each time.
-  def qsort[F[_]: Monad: Parallel: Trace: Timer, A: Order](as: List[A]): F[List[A]] =
-    Trace[F].span(as.mkString(",")) {
-      Timer[F].sleep(10.milli) *> {
-          as match {
-          case Nil    => Monad[F].pure(Nil)
-          case h :: t =>
-            val (a, b) = t.partition(_ <= h)
-            (qsort[F, A](a), qsort[F, A](b)).parMapN(_ ++ List(h) ++ _)
+  def qsort[F[_] : Concurrent : Parallel : Trace : Timer, A: Order](as: List[A]): F[List[A]] = {
+    case class ConcatRequest(left: List[A], mid: A, right: List[A], portal: Portal[F], cb: List[A] => F[Unit])
+
+    Stream.eval(Queue.unbounded[F, ConcatRequest]).flatMap { q =>
+
+      def qsort(as: List[A]): F[List[A]] =
+        Trace[F].span(s"sort ${as.mkString(",")}") {
+          Timer[F].sleep(10.milli) *> {
+            as match {
+              case Nil => Monad[F].pure(Nil)
+              case h :: t =>
+                val (a, b) = t.partition(_ <= h)
+                (qsort(a), qsort(b)).parTupled.flatMap { case (l, r) =>
+                  Deferred[F, List[A]].flatMap { deferred =>
+                    Trace[F].portal.flatMap { portal =>
+                      q.enqueue1(ConcatRequest(l, h, r, portal, deferred.complete))
+                    } *> deferred.get
+                  }
+                }
+            }
+          }
+        }
+      Stream.eval(qsort(as)).concurrently {
+        q.dequeue.evalMap { case ConcatRequest(left, mid, right, portal, cb) =>
+          portal {
+            Trace[F].span(s"concat ${left.mkString(",")} + $mid + ${right.mkString(",")}") {
+              cb(left ++ List(mid) ++ right)
+            }
+          }
         }
       }
-    }
+    }.compile.lastOrError
+  }
+}
+
+object Fs2StreamTrace {
+
 }

--- a/modules/mtl/shared/src/main/scala/LocalTrace.scala
+++ b/modules/mtl/shared/src/main/scala/LocalTrace.scala
@@ -9,26 +9,31 @@ package mtl
 import cats.mtl.Local
 import cats.effect._
 import cats.syntax.all._
+
 import java.net.URI
 
 private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(
   implicit ev: Bracket[F, Throwable]
-) extends Trace[F] {
+) extends UnsafeTrace[F] {
 
-    def kernel: F[Kernel] =
-      local.ask.flatMap(_.kernel)
+  def kernel: F[Kernel] =
+    local.ask.flatMap(_.kernel)
 
-    def put(fields: (String, TraceValue)*): F[Unit] =
-      local.ask.flatMap(_.put(fields: _*))
+  def put(fields: (String, TraceValue)*): F[Unit] =
+    local.ask.flatMap(_.put(fields: _*))
 
-    def span[A](name: String)(k: F[A]): F[A] =
-      local.ask.flatMap { span =>
-        span.span(name).use(local.scope(k))
-      }
+  def span[A](name: String)(k: F[A]): F[A] =
+    local.ask.flatMap { span =>
+      span.span(name).use(local.scope(k))
+    }
 
-    def traceId: F[Option[String]] =
-      local.ask.flatMap(_.traceId)
+  def traceId: F[Option[String]] =
+    local.ask.flatMap(_.traceId)
 
-    def traceUri: F[Option[URI]] =
-      local.ask.flatMap(_.traceUri)
+  def traceUri: F[Option[URI]] =
+    local.ask.flatMap(_.traceUri)
+
+  def runAsChildOf[A](span: Span[F])(fa: F[A]): F[A] = local.scope(fa)(span)
+
+  def current: F[Span[F]] = local.ask
 }

--- a/modules/mtl/shared/src/main/scala/LocalTrace.scala
+++ b/modules/mtl/shared/src/main/scala/LocalTrace.scala
@@ -9,6 +9,8 @@ package mtl
 import cats.mtl.Local
 import cats.effect._
 import cats.syntax.all._
+import cats.~>
+
 import java.net.URI
 
 private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(
@@ -27,7 +29,7 @@ private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(
       }
 
     def portal: F[Portal[F]] = local.ask.map { span =>
-      new Portal[F] {
+      new (F ~> F) {
         def apply[A](fa: F[A]): F[A] = local.scope(fa)(span)
       }
     }

--- a/modules/noop/src/main/scala/NoopTrace.scala
+++ b/modules/noop/src/main/scala/NoopTrace.scala
@@ -9,7 +9,7 @@ import cats.Applicative
 import cats.syntax.all._
 import java.net.URI
 
-final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
+final case class NoopTrace[F[_]: Applicative]() extends UnsafeTrace[F] {
 
   override def put(fields: (String, TraceValue)*): F[Unit] =
     Applicative[F].unit
@@ -19,6 +19,10 @@ final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
 
   override def span[A](name: String)(k: F[A]): F[A] =
     k
+
+  def current: F[Span[F]] = Applicative[F].pure(NoopSpan[F]())
+
+  def runAsChildOf[A](span: Span[F])(fa: F[A]): F[A] = fa
 
   def traceId: F[Option[String]] =
     none.pure[F]

--- a/modules/noop/src/main/scala/NoopTrace.scala
+++ b/modules/noop/src/main/scala/NoopTrace.scala
@@ -5,8 +5,9 @@
 package natchez
 package noop
 
-import cats.Applicative
+import cats.{Applicative, ~>}
 import cats.syntax.all._
+
 import java.net.URI
 
 final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
@@ -21,7 +22,7 @@ final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
     k
 
   override def portal: F[Portal[F]] = Applicative[F].pure(
-    new Portal[F] {
+    new (F ~> F) {
       def apply[A](fa: F[A]): F[A] = fa
     }
   )

--- a/modules/noop/src/main/scala/NoopTrace.scala
+++ b/modules/noop/src/main/scala/NoopTrace.scala
@@ -9,7 +9,7 @@ import cats.Applicative
 import cats.syntax.all._
 import java.net.URI
 
-final case class NoopTrace[F[_]: Applicative]() extends UnsafeTrace[F] {
+final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
 
   override def put(fields: (String, TraceValue)*): F[Unit] =
     Applicative[F].unit
@@ -20,9 +20,11 @@ final case class NoopTrace[F[_]: Applicative]() extends UnsafeTrace[F] {
   override def span[A](name: String)(k: F[A]): F[A] =
     k
 
-  def current: F[Span[F]] = Applicative[F].pure(NoopSpan[F]())
-
-  def runAsChildOf[A](span: Span[F])(fa: F[A]): F[A] = fa
+  override def portal: F[Portal[F]] = Applicative[F].pure(
+    new Portal[F] {
+      def apply[A](fa: F[A]): F[A] = fa
+    }
+  )
 
   def traceId: F[Option[String]] =
     none.pure[F]


### PR DESCRIPTION
This introduces `Portal[F]`, a type alias for `F ~> F`, and adds `def portal: F[Portal[F]]` to `Trace`. The motivation is allowing tracing to take place across asynchronous boundaries, as shown in the modified sorting example.

`Portal` is probably a bad name, I'm open to better ideas