### PR TITLE
Make DDSpan public

### DIFF
--- a/modules/datadog/src/main/scala/DDSpan.scala
+++ b/modules/datadog/src/main/scala/DDSpan.scala
@@ -16,7 +16,7 @@ import natchez.TraceValue.{BooleanValue, NumberValue, StringValue}
 import scala.jdk.CollectionConverters._
 import java.net.URI
 
-private[datadog] final case class DDSpan[F[_]: Sync](
+final case class DDSpan[F[_]: Sync](
   tracer: ot.Tracer,
   span:   ot.Span,
   uriPrefix: Option[URI]


### PR DESCRIPTION
I'm working on a project that uses the datadog jvm agent and grpc. Part of the behaviour of the agent is that it injects interceptors into the grpc client and server instances that manage tracing. So by the time our grpc request handling code is entered a root span has already been created and is available as the active span on the opentracing `GlobalTracer`.

This means that it's not appropriate for our code to use `DDEntryPoint` to initiate our traces, as this will result in a new root being constructed. Instead we should simply construct a new instance of DDSpan from `GlobalTracer` and `activeSpan`. However, `DDSpan` is marked as `private` so our code can't do that. That has resulted in us having to copy the implementation of `DDSpan` into our codebase to do what we need.

This PR removes the `private` declaration from `DDSpan` so that we can construct it directly to handle our situation.