### PR TITLE
OpenTelemetry: Return null when getting a missing header

### DIFF
--- a/modules/opentelemetry/src/main/scala/natchez/opentelemetry/OpenTelemetrySpan.scala
+++ b/modules/opentelemetry/src/main/scala/natchez/opentelemetry/OpenTelemetrySpan.scala
@@ -214,7 +214,7 @@ private[opentelemetry] object OpenTelemetrySpan {
     override def keys(carrier: Kernel): lang.Iterable[String] = carrier.toHeaders.keys.asJava
 
     override def get(carrier: Kernel, key: String): String =
-      carrier.toHeaders(key)
+      carrier.toHeaders.getOrElse(key, null)
   }
 
   private val spanContextSetter = new TextMapSetter[mutable.Map[String, String]] {


### PR DESCRIPTION
If the Propagator expects a header which is missing from the kernel, it catches the `NoSuchElementException`, silently fails the propagation, and instead generates a new trace ID.

```
java.util.NoSuchElementException: key not found: baggage
	at scala.collection.immutable.Map$Map2.apply(Map.scala:298)
	at natchez.opentelemetry.OpenTelemetrySpan$$anon$1.get(OpenTelemetrySpan.scala:168)
	at natchez.opentelemetry.OpenTelemetrySpan$$anon$1.get(OpenTelemetrySpan.scala:167)
	at io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator.extract(W3CBaggagePropagator.java:98)
	at io.opentelemetry.context.propagation.MultiTextMapPropagator.extract(MultiTextMapPropagator.java:65)
	at natchez.opentelemetry.OpenTelemetrySpan$.fromKernel$$anonfun$1(OpenTelemetrySpan.scala:142)
	at cats.effect.IOFiber.runLoop(IOFiber.scala:335)
	at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1322)
	at cats.effect.IOFiber.run(IOFiber.scala:119)
	at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:585)
```

The OpenTelemetry propagators expect either `null` or empty string when a header is missing.