### PR TITLE
Use case insensitive strings for `Kernel` headers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.typelevel" %%% "cats-core" % catsVersion,
       "org.typelevel" %%% "cats-effect-kernel" % catsEffectVersion,
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
-      "co.fs2" %%% "fs2-io" % fs2Version
+      "co.fs2" %%% "fs2-io" % fs2Version,
+      "org.typelevel" %%% "case-insensitive" % "1.3.0"
     )
   )
   .nativeSettings(commonNativeSettings)

--- a/modules/core/shared/src/main/scala/Kernel.scala
+++ b/modules/core/shared/src/main/scala/Kernel.scala
@@ -4,8 +4,21 @@
 
 package natchez
 
+import org.typelevel.ci._
+
+import java.util
+import scala.jdk.CollectionConverters._
+
 /** An opaque hunk of data that we can hand off to another system (in the form of HTTP headers),
   * which can then create new spans as children of this one. By this mechanism we allow our trace
   * to span remote calls.
   */
-final case class Kernel(toHeaders: Map[String, String])
+final case class Kernel(toHeaders: Map[CIString, String]) {
+  private[natchez] def toJava: util.Map[String, String] =
+    toHeaders.map { case (k, v) => k.toString -> v }.asJava
+}
+
+object Kernel {
+  private[natchez] def fromJava(headers: util.Map[String, String]): Kernel =
+    apply(headers.asScala.map { case (k, v) => CIString(k) -> v }.toMap)
+}

--- a/modules/datadog/src/main/scala/DDEntryPoint.scala
+++ b/modules/datadog/src/main/scala/DDEntryPoint.scala
@@ -11,7 +11,6 @@ import io.opentracing.propagation.{Format, TextMapAdapter}
 import io.{opentracing => ot}
 
 import java.net.URI
-import scala.jdk.CollectionConverters._
 
 final class DDEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[URI])
     extends EntryPoint[F] {
@@ -26,7 +25,7 @@ final class DDEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[URI])
         Sync[F].delay {
           val spanContext = tracer.extract(
             Format.Builtin.HTTP_HEADERS,
-            new TextMapAdapter(kernel.toHeaders.asJava)
+            new TextMapAdapter(kernel.toJava)
           )
           tracer.buildSpan(name).asChildOf(spanContext).start()
         }

--- a/modules/datadog/src/main/scala/DDSpan.scala
+++ b/modules/datadog/src/main/scala/DDSpan.scala
@@ -35,7 +35,7 @@ final case class DDSpan[F[_]: Sync](
         Format.Builtin.HTTP_HEADERS,
         new TextMapAdapter(m)
       )
-      Kernel(m.asScala.toMap)
+      Kernel.fromJava(m)
     }
 
   def put(fields: (String, TraceValue)*): F[Unit] =
@@ -55,7 +55,7 @@ final case class DDSpan[F[_]: Sync](
 
   override def makeSpan(name: String, options: Span.Options): Resource[F, Span[F]] = {
     val parent = options.parentKernel.map(k =>
-      tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(k.toHeaders.asJava))
+      tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(k.toJava))
     )
     Span.putErrorFields(
       Resource

--- a/modules/honeycomb/src/main/scala/HoneycombSpan.scala
+++ b/modules/honeycomb/src/main/scala/HoneycombSpan.scala
@@ -14,6 +14,7 @@ import java.time.Instant
 import java.util.UUID
 import natchez._
 import java.net.URI
+import org.typelevel.ci._
 
 private[honeycomb] final case class HoneycombSpan[F[_]: Sync](
     client: HoneyClient,
@@ -77,8 +78,8 @@ private[honeycomb] final case class HoneycombSpan[F[_]: Sync](
 private[honeycomb] object HoneycombSpan {
 
   object Headers {
-    val TraceId = "X-Natchez-Trace-Id"
-    val SpanId = "X-Natchez-Parent-Span-Id"
+    val TraceId = ci"X-Natchez-Trace-Id"
+    val SpanId = ci"X-Natchez-Parent-Span-Id"
   }
 
   private def uuid[F[_]: Sync]: F[UUID] =

--- a/modules/jaeger/src/main/scala/JaegerEntryPoint.scala
+++ b/modules/jaeger/src/main/scala/JaegerEntryPoint.scala
@@ -11,7 +11,6 @@ import io.jaegertracing.internal.exceptions.UnsupportedFormatException
 import io.opentracing.propagation.{Format, TextMapAdapter}
 import io.{opentracing => ot}
 
-import scala.jdk.CollectionConverters._
 import java.net.URI
 
 final class JaegerEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[URI])
@@ -22,7 +21,7 @@ final class JaegerEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[UR
         Sync[F].delay {
           val p = tracer.extract(
             Format.Builtin.HTTP_HEADERS,
-            new TextMapAdapter(kernel.toHeaders.asJava)
+            new TextMapAdapter(kernel.toJava)
           )
           tracer.buildSpan(name).asChildOf(p).start()
         }

--- a/modules/jaeger/src/main/scala/JaegerSpan.scala
+++ b/modules/jaeger/src/main/scala/JaegerSpan.scala
@@ -35,7 +35,7 @@ private[jaeger] final case class JaegerSpan[F[_]: Sync](
         Format.Builtin.HTTP_HEADERS,
         new TextMapAdapter(m)
       )
-      Kernel(m.asScala.toMap)
+      Kernel.fromJava(m)
     }
 
   override def put(fields: (String, TraceValue)*): F[Unit] =
@@ -75,7 +75,7 @@ private[jaeger] final case class JaegerSpan[F[_]: Sync](
         val p = options.parentKernel.map(k =>
           tracer.extract(
             Format.Builtin.HTTP_HEADERS,
-            new TextMapAdapter(k.toHeaders.asJava)
+            new TextMapAdapter(k.toJava)
           )
         )
         Sync[F]

--- a/modules/lightstep/src/main/scala/LightstepEntryPoint.scala
+++ b/modules/lightstep/src/main/scala/LightstepEntryPoint.scala
@@ -10,8 +10,6 @@ import cats.syntax.all._
 import io.opentracing.Tracer
 import io.opentracing.propagation.{Format, TextMapAdapter}
 
-import scala.jdk.CollectionConverters._
-
 final class LightstepEntryPoint[F[_]: Sync](tracer: Tracer) extends EntryPoint[F] {
   override def root(name: String): Resource[F, Span[F]] =
     Resource
@@ -23,7 +21,7 @@ final class LightstepEntryPoint[F[_]: Sync](tracer: Tracer) extends EntryPoint[F
       .make(
         Sync[F].delay {
           val p =
-            tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(kernel.toHeaders.asJava))
+            tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(kernel.toJava))
           tracer.buildSpan(name).asChildOf(p).start()
         }
       )(s => Sync[F].delay(s.finish()))

--- a/modules/lightstep/src/main/scala/LightstepSpan.scala
+++ b/modules/lightstep/src/main/scala/LightstepSpan.scala
@@ -27,7 +27,7 @@ private[lightstep] final case class LightstepSpan[F[_]: Sync](
     Sync[F].delay {
       val m = new java.util.HashMap[String, String]
       tracer.inject(span.context, Format.Builtin.HTTP_HEADERS, new TextMapAdapter(m))
-      Kernel(m.asScala.toMap)
+      Kernel.fromJava(m)
     }
 
   override def put(fields: (String, TraceValue)*): F[Unit] =
@@ -63,7 +63,7 @@ private[lightstep] final case class LightstepSpan[F[_]: Sync](
 
   override def makeSpan(name: String, options: Span.Options): Resource[F, Span[F]] = {
     val p = options.parentKernel.map(k =>
-      tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(k.toHeaders.asJava))
+      tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(k.toJava))
     )
     Span.putErrorFields(
       Resource

--- a/modules/log-odin/src/main/scala/LogSpan.scala
+++ b/modules/log-odin/src/main/scala/LogSpan.scala
@@ -19,6 +19,7 @@ import io.circe.syntax._
 import io.circe.JsonObject
 import io.odin.Logger
 import java.net.URI
+import org.typelevel.ci._
 
 private[logodin] final case class LogSpan[F[_]: Sync: Logger](
     service: String,
@@ -130,8 +131,8 @@ private[logodin] object LogSpan {
     }
 
   object Headers {
-    val TraceId = "X-Natchez-Trace-Id"
-    val SpanId = "X-Natchez-Parent-Span-Id"
+    val TraceId = ci"X-Natchez-Trace-Id"
+    val SpanId = ci"X-Natchez-Parent-Span-Id"
   }
 
   private def uuid[F[_]: Sync]: F[UUID] =

--- a/modules/log/shared/src/main/scala/LogSpan.scala
+++ b/modules/log/shared/src/main/scala/LogSpan.scala
@@ -20,6 +20,7 @@ import io.circe.Encoder
 import io.circe.syntax._
 import io.circe.JsonObject
 import org.typelevel.log4cats.Logger
+import org.typelevel.ci._
 
 import java.net.URI
 
@@ -125,8 +126,8 @@ private[log] object LogSpan {
     }
 
   object Headers {
-    val TraceId = "X-Natchez-Trace-Id"
-    val SpanId = "X-Natchez-Parent-Span-Id"
+    val TraceId = ci"X-Natchez-Trace-Id"
+    val SpanId = ci"X-Natchez-Parent-Span-Id"
   }
 
   private def uuid[F[_]: Sync]: F[UUID] =

--- a/modules/newrelic/src/main/scala/natchez/newrelic/NewrelicSpan.scala
+++ b/modules/newrelic/src/main/scala/natchez/newrelic/NewrelicSpan.scala
@@ -15,6 +15,7 @@ import com.newrelic.telemetry.spans.{Span, SpanBatch, SpanBatchSender}
 import natchez.TraceValue.{BooleanValue, NumberValue, StringValue}
 import natchez.newrelic.NewrelicSpan.Headers
 import natchez.{Kernel, TraceValue}
+import org.typelevel.ci._
 
 import scala.jdk.CollectionConverters._
 
@@ -70,8 +71,8 @@ private[newrelic] final case class NewrelicSpan[F[_]: Sync](
 
 object NewrelicSpan {
   object Headers {
-    val TraceId = "X-Natchez-Trace-Id"
-    val SpanId = "X-Natchez-Parent-Span-Id"
+    val TraceId = ci"X-Natchez-Trace-Id"
+    val SpanId = ci"X-Natchez-Parent-Span-Id"
   }
 
   def fromKernel[F[_]: Sync](

--- a/modules/opencensus/src/main/scala/OpenCensusSpan.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusSpan.scala
@@ -14,6 +14,7 @@ import io.opencensus.trace.{AttributeValue, Sampler, Tracer, Tracing}
 import io.opencensus.trace.propagation.SpanContextParseException
 import io.opencensus.trace.propagation.TextFormat.Getter
 import natchez.TraceValue.{BooleanValue, NumberValue, StringValue}
+import org.typelevel.ci._
 
 import scala.collection.mutable
 import java.net.URI
@@ -51,7 +52,7 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
     Sync[F].delay(span.addAnnotation(event)).void
 
   override def kernel: F[Kernel] = Sync[F].delay {
-    val headers: mutable.Map[String, String] = mutable.Map.empty[String, String]
+    val headers: mutable.Map[CIString, String] = mutable.Map.empty[CIString, String]
     Tracing.getPropagationComponent.getB3Format
       .inject(span.getContext, headers, spanContextSetter)
     Kernel(headers.toMap)
@@ -89,9 +90,9 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
 }
 
 private[opencensus] object OpenCensusSpan {
-  private val spanContextSetter = new Setter[mutable.Map[String, String]] {
-    override def put(carrier: mutable.Map[String, String], key: String, value: String): Unit = {
-      carrier.put(key, value)
+  private val spanContextSetter = new Setter[mutable.Map[CIString, String]] {
+    override def put(carrier: mutable.Map[CIString, String], key: String, value: String): Unit = {
+      carrier.put(CIString(key), value)
       ()
     }
   }
@@ -188,5 +189,5 @@ private[opencensus] object OpenCensusSpan {
     }
 
   private val spanContextGetter: Getter[Kernel] = (carrier: Kernel, key: String) =>
-    carrier.toHeaders(key)
+    carrier.toHeaders(CIString(key))
 }

--- a/modules/xray/src/main/scala/natchez/xray/XRaySpan.scala
+++ b/modules/xray/src/main/scala/natchez/xray/XRaySpan.scala
@@ -21,6 +21,7 @@ import io.circe.syntax._
 import cats.effect.kernel.Resource.ExitCase.Canceled
 import cats.effect.kernel.Resource.ExitCase.Errored
 import cats.effect.kernel.Resource.ExitCase.Succeeded
+import org.typelevel.ci._
 
 import scala.concurrent.duration._
 import scala.util.matching.Regex
@@ -154,7 +155,7 @@ private[xray] object XRaySpan {
       case NumberValue(n)                       => n.doubleValue.asJson
     }
 
-  val Header = "X-Amzn-Trace-Id"
+  val Header = ci"X-Amzn-Trace-Id"
 
   private[xray] def encodeHeader(
       rootId: String,


### PR DESCRIPTION
This should be more robust and interop better with http4s.