### PR TITLE
Add `Trace#spanK`

### DIFF
--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -38,6 +38,12 @@ trait Trace[F[_]] {
   /** Create a new span, and within it run the continuation `k`. */
   def span[A](name: String, options: Span.Options = Span.Options.Defaults)(k: F[A]): F[A]
 
+  /** Same as [[span]], expressed as a [[cats.arrow.FunctionK]]. */
+  def spanK[A](name: String, options: Span.Options = Span.Options.Defaults): F ~> F =
+    new (F ~> F) {
+      def apply[A](fa: F[A]): F[A] = span(name, options)(fa)
+    }
+
   /** A unique ID for this trace, if available. This can be useful to include in error messages for
     * example, so you can quickly find the associated trace.
     */

--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -39,7 +39,7 @@ trait Trace[F[_]] {
   def span[A](name: String, options: Span.Options = Span.Options.Defaults)(k: F[A]): F[A]
 
   /** Same as [[span]], expressed as a [[cats.arrow.FunctionK]]. */
-  def spanK[A](name: String, options: Span.Options = Span.Options.Defaults): F ~> F =
+  def spanK(name: String, options: Span.Options = Span.Options.Defaults): F ~> F =
     new (F ~> F) {
       def apply[A](fa: F[A]): F[A] = span(name, options)(fa)
     }


### PR DESCRIPTION
`span` expressed as a `FunctionK`.

At risk of having too many ways to do things: the difference between `spanR` and `spanK` is that:
- `spanR` creates _one_ span, and shares it every time the transformation is applied. Its parent is determined by where the resource is acquired.
- `spanK` creates a new span every time the transformation is applied. Its parent is determined by where the transformation is applied.