### PR TITLE
use opentelemetry standard names for honeycomb

### DIFF
--- a/modules/docs/src/main/paradox/backends/honeycomb.md
+++ b/modules/docs/src/main/paradox/backends/honeycomb.md
@@ -40,7 +40,7 @@ Honeycomb spans include the following fields, in addition to any user-specified 
 
 | Field                | Type                    | Meaning                             |
 |----------------------|-------------------------|-------------------------------------|
-| `service_name`       | String                  | User-supplied service name.         |
+| `service.name`       | String                  | User-supplied service name.         |
 | `name`               | String                  | User-supplied span name.            |
 | `trace.trace_id`     | String (UUID)           | Id shared by all spans in a trace.  |
 | `trace.span_id`      | String (UUID)           | Id of the parent span, if any.      |

--- a/modules/honeycomb/src/main/scala/Honeycomb.scala
+++ b/modules/honeycomb/src/main/scala/Honeycomb.scala
@@ -23,7 +23,7 @@ object Honeycomb {
       .make {
         for {
           b <- Sync[F].delay(
-            LibHoney.options.setGlobalFields(Map("service_name" -> service).asJava)
+            LibHoney.options.setGlobalFields(Map("service.name" -> service).asJava)
           )
           o <- f(b)
           c <- Sync[F].delay(LibHoney.create(o))


### PR DESCRIPTION
Hi,
wondering if the default field for the service name should follow the OT standard (preferred Honeycomb solution).
I understand this is a breaking change, we could add a default parameter in `entryPoint ' or add both fields to preserve compatibility.
We currently adopt the latter solution.