### PR TITLE
accept optional arbitrary fields when attaching an error to a span

### DIFF
--- a/modules/core/shared/src/main/scala/Span.scala
+++ b/modules/core/shared/src/main/scala/Span.scala
@@ -25,7 +25,7 @@ trait Span[F[_]] {
   def log(event: String): F[Unit]
 
   /** Adds error information to this span. */
-  def attachError(err: Throwable): F[Unit]
+  def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit]
 
   /** The kernel for this span, which can be sent as headers to remote systems, which can then
     * continue this trace by constructing spans that are children of this one.
@@ -63,8 +63,8 @@ trait Span[F[_]] {
 
       override def kernel: G[Kernel] = f(outer.kernel)
 
-      override def attachError(err: Throwable) =
-        f(outer.attachError(err))
+      override def attachError(err: Throwable, fields: (String, TraceValue)*) =
+        f(outer.attachError(err, fields: _*))
 
       override def log(event: String) =
         f(outer.log(event))
@@ -126,7 +126,7 @@ object Span {
   private abstract class EphemeralSpan[F[_]: Applicative] extends Span[F] {
     override def put(fields: (String, TraceValue)*): F[Unit] = ().pure[F]
     override def kernel: F[Kernel] = Kernel(Map.empty).pure[F]
-    override def attachError(err: Throwable) = ().pure[F]
+    override def attachError(err: Throwable, fields: (String, TraceValue)*) = ().pure[F]
     override def log(event: String) = ().pure[F]
     override def log(fields: (String, TraceValue)*) = ().pure[F]
     override def spanId: F[Option[String]] = (None: Option[String]).pure[F]

--- a/modules/core/shared/src/test/scala/InMemory.scala
+++ b/modules/core/shared/src/test/scala/InMemory.scala
@@ -24,8 +24,8 @@ object InMemory {
     def put(fields: (String, natchez.TraceValue)*): IO[Unit] =
       ref.update(_.append(lineage -> NatchezCommand.Put(fields.toList)))
 
-    def attachError(err: Throwable): IO[Unit] =
-      ref.update(_.append(lineage -> NatchezCommand.AttachError(err)))
+    def attachError(err: Throwable, fields: (String, TraceValue)*): IO[Unit] =
+      ref.update(_.append(lineage -> NatchezCommand.AttachError(err, fields.toList)))
 
     def log(event: String): IO[Unit] =
       ref.update(_.append(lineage -> NatchezCommand.LogEvent(event)))
@@ -101,7 +101,8 @@ object InMemory {
     case class Put(fields: List[(String, natchez.TraceValue)]) extends NatchezCommand
     case class CreateSpan(name: String, kernel: Option[Kernel]) extends NatchezCommand
     case class ReleaseSpan(name: String) extends NatchezCommand
-    case class AttachError(err: Throwable) extends NatchezCommand
+    case class AttachError(err: Throwable, fields: List[(String, TraceValue)])
+        extends NatchezCommand
     case class LogEvent(event: String) extends NatchezCommand
     case class LogFields(fields: List[(String, TraceValue)]) extends NatchezCommand
     // entry point

--- a/modules/honeycomb/src/main/scala/HoneycombSpan.scala
+++ b/modules/honeycomb/src/main/scala/HoneycombSpan.scala
@@ -66,11 +66,12 @@ private[honeycomb] final case class HoneycombSpan[F[_]: Sync](
   def traceUri: F[Option[URI]] =
     none.pure[F] // TODO
 
-  override def attachError(err: Throwable): F[Unit] =
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
     put(
-      "exit.case" -> "error",
-      "exit.error.class" -> err.getClass.getName,
-      "exit.error.message" -> err.getMessage
+      "exit.case" -> TraceValue.StringValue("error") ::
+        "exit.error.class" -> TraceValue.StringValue(err.getClass.getName) ::
+        "exit.error.message" -> TraceValue.StringValue(err.getMessage) ::
+        fields.toList: _*
     )
 
 }

--- a/modules/jaeger/src/main/scala/JaegerSpan.scala
+++ b/modules/jaeger/src/main/scala/JaegerSpan.scala
@@ -45,19 +45,19 @@ private[jaeger] final case class JaegerSpan[F[_]: Sync](
       case (k, BooleanValue(v)) => Sync[F].delay(span.setTag(k, v))
     }
 
-  override def attachError(err: Throwable): F[Unit] =
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
     put(
       Tags.ERROR.getKey -> true
     ) >>
       Sync[F].delay {
         span.log(
-          Map(
+          (Map(
             Fields.EVENT -> "error",
             Fields.ERROR_OBJECT -> err,
             Fields.ERROR_KIND -> err.getClass.getSimpleName,
             Fields.MESSAGE -> err.getMessage,
             Fields.STACK -> err.getStackTrace.mkString
-          ).asJava
+          ) ++ fields.toList.nested.map(_.value).value.toMap).asJava
         )
       }.void
 

--- a/modules/lightstep/src/main/scala/LightstepSpan.scala
+++ b/modules/lightstep/src/main/scala/LightstepSpan.scala
@@ -37,19 +37,19 @@ private[lightstep] final case class LightstepSpan[F[_]: Sync](
       case (k, BooleanValue(v)) => Sync[F].delay(span.setTag(k, v))
     }
 
-  override def attachError(err: Throwable): F[Unit] =
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
     put(
       Tags.ERROR.getKey -> true
     ) >>
       Sync[F].delay {
         span.log(
-          Map(
+          (Map(
             Fields.EVENT -> "error",
             Fields.ERROR_OBJECT -> err,
             Fields.ERROR_KIND -> err.getClass.getSimpleName,
             Fields.MESSAGE -> err.getMessage,
             Fields.STACK -> err.getStackTrace.mkString
-          ).asJava
+          ) ++ fields.toList.nested.map(_.value).value.toMap).asJava
         )
       }.void
 

--- a/modules/log-odin/src/main/scala/LogSpan.scala
+++ b/modules/log-odin/src/main/scala/LogSpan.scala
@@ -63,8 +63,12 @@ private[logodin] final case class LogSpan[F[_]: Sync: Logger](
   def putAny(fields: (String, Json)*): F[Unit] =
     this.fields.update(_ ++ fields.toMap)
 
-  def attachError(err: Throwable): F[Unit] =
-    put("error.message" -> err.getMessage, "error.class" -> err.getClass.getSimpleName)
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    put(
+      ("error.message" -> TraceValue.StringValue(err.getMessage)) ::
+        ("error.class" -> TraceValue.StringValue(err.getClass.getSimpleName)) ::
+        fields.toList: _*
+    )
 
   def log(event: String): F[Unit] = Applicative[F].unit
 

--- a/modules/log/shared/src/main/scala/LogSpan.scala
+++ b/modules/log/shared/src/main/scala/LogSpan.scala
@@ -69,13 +69,13 @@ private[log] final case class LogSpan[F[_]: Sync: Logger](
       Resource.makeCase(LogSpan.child(this, label, options))(LogSpan.finishChild[F]).widen
     )
 
-  def attachError(err: Throwable): F[Unit] =
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
     putAny(
       "exit.case" -> "error".asJson,
       "exit.error.class" -> err.getClass.getName.asJson,
       "exit.error.message" -> err.getMessage.asJson,
       "exit.error.stackTrace" -> err.getStackTrace.map(_.toString).asJson
-    )
+    ) *> put(fields: _*)
 
   def json(finish: Instant): F[JsonObject] =
     (fields.get, children.get).mapN { (fs, cs) =>

--- a/modules/mtl/shared/src/main/scala/LocalTrace.scala
+++ b/modules/mtl/shared/src/main/scala/LocalTrace.scala
@@ -23,8 +23,8 @@ private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(implicit
   override def put(fields: (String, TraceValue)*): F[Unit] =
     local.ask.flatMap(_.put(fields: _*))
 
-  override def attachError(err: Throwable): F[Unit] =
-    local.ask.flatMap(_.attachError(err))
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    local.ask.flatMap(_.attachError(err, fields: _*))
 
   override def log(fields: (String, TraceValue)*): F[Unit] =
     local.ask.flatMap(_.log(fields: _*))

--- a/modules/newrelic/src/main/scala/natchez/newrelic/NewrelicSpan.scala
+++ b/modules/newrelic/src/main/scala/natchez/newrelic/NewrelicSpan.scala
@@ -50,8 +50,12 @@ private[newrelic] final case class NewrelicSpan[F[_]: Sync](
       case (k, BooleanValue(v)) => attributes.update(att => att.put(k, v))
     }
 
-  override def attachError(err: Throwable): F[Unit] =
-    put("error.message" -> err.getMessage, "error.class" -> err.getClass.getSimpleName)
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    put(
+      ("error.message" -> TraceValue.StringValue(err.getMessage)) ::
+        ("error.class" -> TraceValue.StringValue(err.getClass.getSimpleName)) ::
+        fields.toList: _*
+    )
 
   override def log(fields: (String, TraceValue)*): F[Unit] = Sync[F].unit
 

--- a/modules/noop/shared/src/main/scala/NoopSpan.scala
+++ b/modules/noop/shared/src/main/scala/NoopSpan.scala
@@ -16,7 +16,8 @@ final case class NoopSpan[F[_]: Applicative]() extends Span[F] {
   override def put(fields: (String, TraceValue)*): F[Unit] =
     Applicative[F].unit
 
-  override def attachError(err: Throwable): F[Unit] = Applicative[F].unit
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    Applicative[F].unit
 
   override def log(fields: (String, TraceValue)*): F[Unit] =
     Applicative[F].unit

--- a/modules/noop/shared/src/main/scala/NoopTrace.scala
+++ b/modules/noop/shared/src/main/scala/NoopTrace.scala
@@ -17,7 +17,8 @@ final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
   override def put(fields: (String, TraceValue)*): F[Unit] =
     Applicative[F].unit
 
-  def attachError(err: Throwable): F[Unit] = Applicative[F].unit
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    Applicative[F].unit
 
   override def kernel: F[Kernel] =
     Applicative[F].pure(Kernel(Map.empty))

--- a/modules/opencensus/src/main/scala/OpenCensusSpan.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusSpan.scala
@@ -85,8 +85,12 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
 
   def traceUri: F[Option[URI]] = none.pure[F]
 
-  override def attachError(err: Throwable): F[Unit] =
-    put("error.message" -> err.getMessage, "error.class" -> err.getClass.getSimpleName)
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    put(
+      ("error.message" -> TraceValue.StringValue(err.getMessage)) ::
+        ("error.class" -> TraceValue.StringValue(err.getClass.getSimpleName)) ::
+        fields.toList: _*
+    )
 }
 
 private[opencensus] object OpenCensusSpan {

--- a/modules/opentelemetry/src/main/scala/natchez/opentelemetry/OpenTelemetrySpan.scala
+++ b/modules/opentelemetry/src/main/scala/natchez/opentelemetry/OpenTelemetrySpan.scala
@@ -74,9 +74,9 @@ private[opentelemetry] final case class OpenTelemetrySpan[F[_]: Sync](
       Kernel(headers.toMap)
     }
 
-  override def attachError(err: Throwable): F[Unit] =
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
     put("error.message" -> err.getMessage, "error.class" -> err.getClass.getSimpleName) *>
-      Sync[F].delay(span.recordException(err)).void
+      Sync[F].delay(span.recordException(err, fieldsToAttributes(fields: _*))).void
 
   override def log(fields: (String, TraceValue)*): F[Unit] =
     Sync[F].delay(span.addEvent("event", fieldsToAttributes(fields: _*))).void

--- a/modules/xray/src/main/scala/natchez/xray/XRaySpan.scala
+++ b/modules/xray/src/main/scala/natchez/xray/XRaySpan.scala
@@ -48,8 +48,12 @@ private[xray] final case class XRaySpan[F[_]: Concurrent: Clock: Random](
   def kernel: F[Kernel] =
     Kernel(Map(XRaySpan.Header -> header)).pure[F]
 
-  def attachError(err: Throwable): F[Unit] =
-    put("error.message" -> err.getMessage, "error.class" -> err.getClass.getSimpleName)
+  override def attachError(err: Throwable, fields: (String, TraceValue)*): F[Unit] =
+    put(
+      ("error.message" -> TraceValue.StringValue(err.getMessage)) ::
+        ("error.class" -> TraceValue.StringValue(err.getClass.getSimpleName)) ::
+        fields.toList: _*
+    )
 
   def log(event: String): F[Unit] = Applicative[F].unit
 


### PR DESCRIPTION
Without this change, it's still possible to attach arbitrary fields onto an event using `log` (or onto a span itself using `put`), but for at least the OpenTelemetry backend, that results in the exception being placed on a distinct event on the span from the other fields. Keeping them together seems more semantically sound.

If this is merged, I plan to use it [here in log4cats-natchez](https://github.com/typelevel/log4cats-natchez/blob/2f0de488937f8a9621b615a42b92d3c21c4b0d71/core/shared/src/main/scala/org/typelevel/log4cats/natchez/package.scala#L54). That line would probably become something like

```scala
maybeThrowable.fold(Trace[F].log(attributes: _*))(Trace[F].attachError(_, attributes: _*))
```

Arguably, we could also make a very similar addition to the `def log(event: String): F[Unit]` method, but I think it's less necessary there because AFAICT, for most of the backends, you can achieve the same result by using `def log(fields: (String, TraceValue)*): F[Unit]` and adding an `"event" -> TraceValue.StringValue(event)` with the rest of the attributes being set.